### PR TITLE
feat: accept format arguments in ice!() macro invocation

### DIFF
--- a/compiler/eight-diagnostics/src/lib.rs
+++ b/compiler/eight-diagnostics/src/lib.rs
@@ -1,13 +1,12 @@
 #[macro_export]
 macro_rules! ice {
-    ($message:expr) => {{
-        let message = $message;
+    ($($arg:tt)*) => {{
         let file = file!();
         let line = line!();
         let column = column!();
         panic!(
             "internal compiler error ({}:{}:{}):\n{}",
-            file, line, column, message
+            file, line, column, format_args!($($arg)*)
         )
     }};
 }

--- a/compiler/eight-driver/src/operations/emit_hir.rs
+++ b/compiler/eight-driver/src/operations/emit_hir.rs
@@ -21,7 +21,7 @@ impl HirEmitOperation {
                     .body
                     .functions
                     .get(&name)
-                    .unwrap_or_else(|| ice!(format!("function {} not found", name)));
+                    .unwrap_or_else(|| ice!("function {} not found", name));
                 Ok(textual_pass.visit_function(function))
             }
         }

--- a/compiler/eight-driver/src/operations/emit_mir.rs
+++ b/compiler/eight-driver/src/operations/emit_mir.rs
@@ -19,7 +19,7 @@ impl EmitMirOperation {
                 let function = module
                     .data()
                     .get_function_by_name(name)
-                    .unwrap_or_else(|| ice!(format!("function {} not found", name)));
+                    .unwrap_or_else(|| ice!("function {} not found", name));
                 Ok(textual_pass.visit_function(module.data(), function))
             }
         }

--- a/compiler/eight-middle/src/hir.rs
+++ b/compiler/eight-middle/src/hir.rs
@@ -675,10 +675,10 @@ impl<'hir> HirInstanceSignature<'hir> {
         trait_sig: &'hir HirTraitSignature<'hir>,
     ) -> Vec<&'hir HirTy<'hir>> {
         let Some(function) = self.methods.get(method) else {
-            ice!(format!(
+            ice!(
                 "attempted to find output types for non-existent method {}",
                 method
-            ));
+            );
         };
         let mut outputs = HashSet::<StableRef<'hir, HirTy<'hir>>>::new();
         fn visit<'hir>(

--- a/compiler/eight-middle/src/hir_lowering_pass/mod.rs
+++ b/compiler/eight-middle/src/hir_lowering_pass/mod.rs
@@ -51,13 +51,10 @@ impl<'hir, 'mir> MirModuleLoweringPass<'mir> {
         for function in module.body.functions.values() {
             let name = self.cc.intern_str(function.name);
             let Some(id) = module_builder.data().get_function_id(name) else {
-                ice!(format!("failed to find function id for {}", function.name));
+                ice!("failed to find function id for {}", function.name);
             };
             let Some(ty) = module_builder.data().get_function_type(id) else {
-                ice!(format!(
-                    "failed to find function type for {}",
-                    function.name
-                ));
+                ice!("failed to find function type for {}", function.name);
             };
             let mut builder = MirFunctionBuilder::new(self.cc, name, ty, id);
             self.visit_function(function, &mut builder, &module_builder)?;
@@ -218,7 +215,7 @@ impl<'hir, 'mir> MirModuleLoweringPass<'mir> {
     ) -> MirResult<MirValueId> {
         // Arguments can be used directly, but locals need to be loaded.
         let id = self.locals.find(&expr.name).unwrap_or_else(|| {
-            ice!(format!("failed to find local value for {}", expr.name));
+            ice!("failed to find local value for {}", expr.name);
         });
         let value_ty = b.data().get_value_type(*id);
         let expected_ty = self.visit_ty(expr.ty)?;
@@ -242,10 +239,10 @@ impl<'hir, 'mir> MirModuleLoweringPass<'mir> {
                 // TODO: Mangle the name along with the type arguments.
                 let name = self.cc.intern_str(s.name);
                 let id = cx.data().get_function_id(name).unwrap_or_else(|| {
-                    ice!(format!(
+                    ice!(
                         "failed to find function id for {} despite passing type checker",
                         name
-                    ));
+                    );
                 });
                 Ok(b.build_function_ref(id))
             }

--- a/compiler/eight-middle/src/hir_type_check_pass/mod.rs
+++ b/compiler/eight-middle/src/hir_type_check_pass/mod.rs
@@ -246,10 +246,11 @@ impl HirModuleTypeCheckerPass {
 
         for (field_name, field_declaration) in node.signature.fields.iter() {
             let field_ty = node.instantiated_fields.get(field_name).unwrap_or_else(|| {
-                ice!(format!(
+                ice!(
                     "field {} not found in struct type {}",
-                    field_name, node.name
-                ))
+                    field_name,
+                    node.name
+                )
             });
             let is_directly_self_referential =
                 matches!(field_ty, HirTy::Nominal(n) if std::ptr::eq(n.name, node.name));
@@ -325,7 +326,7 @@ impl HirModuleTypeCheckerPass {
             let r#trait = cx
                 .signature
                 .query_trait_by_name(node.name)
-                .unwrap_or_else(|| ice!(format!("trait {} not found", node.name)));
+                .unwrap_or_else(|| ice!("trait {} not found", node.name));
 
             // This is an ownership workaround. Ideally this should be checked above the loop, but
             // works here, because instances are syntactically required to have at least one type
@@ -342,10 +343,10 @@ impl HirModuleTypeCheckerPass {
                 ));
             }
             let Some(type_parameter) = r#trait.type_parameters.get(argument_index) else {
-                ice!(format!(
+                ice!(
                     "type parameter at position {} did not exist after check",
                     argument_index
-                ));
+                );
             };
             // Hack around the borrow checker. This returns the exact same value, but the lifetime
             // of the reference is not tied to `r#trait` anymore.

--- a/compiler/eight-middle/src/hir_type_check_pass/typing_context.rs
+++ b/compiler/eight-middle/src/hir_type_check_pass/typing_context.rs
@@ -330,10 +330,11 @@ impl<'hir> TypingContext<'hir> {
             .signature
             .query_trait_and_signature_by_name(sym.trait_name, sym.method_name)
         else {
-            ice!(format!(
+            ice!(
                 "called infer() on '{}::{}' that doesn't exist in the context",
-                sym.trait_name, sym.method_name
-            ));
+                sym.trait_name,
+                sym.method_name
+            );
         };
         // Instantiate all the generic types present on both the trait and the method.
         let mut instantiations = HashMap::new();
@@ -958,10 +959,10 @@ impl<'hir> TypingContext<'hir> {
             .methods
             .get(&constraint.method_name)
             .unwrap_or_else(|| {
-                ice!(format!(
+                ice!(
                     "trait instance does not have method {}",
                     constraint.method_name
-                ))
+                )
             });
         let _ = constraint
             .method_type_arguments

--- a/compiler/eight-middle/src/mir.rs
+++ b/compiler/eight-middle/src/mir.rs
@@ -365,7 +365,7 @@ impl<'mir> MirFunctionData<'mir> {
     pub fn get_instruction(&self, id: MirInstructionId) -> &MirInstruction<'mir> {
         self.instructions
             .get(&id)
-            .unwrap_or_else(|| ice!(format!("missing instruction {}", id.0)))
+            .unwrap_or_else(|| ice!("missing instruction {}", id.0))
     }
 
     /// Get the type the instruction evaluates to.
@@ -381,7 +381,7 @@ impl<'mir> MirFunctionData<'mir> {
     pub fn get_basic_block(&self, id: MirBasicBlockId) -> &MirBasicBlock<'mir> {
         self.blocks
             .get(&id)
-            .unwrap_or_else(|| ice!(format!("missing block {}", id.0)))
+            .unwrap_or_else(|| ice!("missing block {}", id.0))
     }
 
     pub fn values(&self) -> impl Iterator<Item = &MirValue<'mir>> {
@@ -392,7 +392,7 @@ impl<'mir> MirFunctionData<'mir> {
     pub fn get_value(&self, id: MirValueId) -> &MirValue<'mir> {
         self.values
             .get(&id)
-            .unwrap_or_else(|| ice!(format!("missing value {}", id.0)))
+            .unwrap_or_else(|| ice!("missing value {}", id.0))
     }
 
     /// Get the type of the value with the given id.


### PR DESCRIPTION
Fixes #8

The macro for internal compiler errors now accepts format specifiers like format!() does.
