### PR TITLE
refactor: consistently name hir and mir types

### DIFF
--- a/compiler/eight-codegen-llvm/src/lib.rs
+++ b/compiler/eight-codegen-llvm/src/lib.rs
@@ -5,7 +5,7 @@ use eight_diagnostics::ice;
 use eight_middle::mir::{
     MirAllocaInstruction, MirBasicBlock, MirBasicBlockId, MirCallInstruction, MirConstantBool,
     MirConstantInteger32, MirFunction, MirFunctionData, MirFunctionType, MirInstruction,
-    MirInstructionId, MirLoadInstruction, MirModule, MirModuleData, MirStoreInstruction, MirType,
+    MirInstructionId, MirLoadInstruction, MirModule, MirModuleData, MirStoreInstruction, MirTy,
     MirValue, MirValueId,
 };
 use inkwell::basic_block::BasicBlock;
@@ -289,18 +289,18 @@ impl<'l, 'mir> MirModuleLLVMCodeGeneratorPass<'l> {
             .collect::<Vec<_>>()
             .into_boxed_slice();
         match node.return_type {
-            MirType::Void(_) => self.context.void_type().fn_type(&arguments, false),
+            MirTy::Void(_) => self.context.void_type().fn_type(&arguments, false),
             _ => self.visit_type(node.return_type).fn_type(&arguments, false),
         }
     }
 
     /// Translate a MIR type into an LLVM type.
-    pub fn visit_type(&mut self, node: &'mir MirType<'mir>) -> BasicTypeEnum<'l> {
+    pub fn visit_type(&mut self, node: &'mir MirTy<'mir>) -> BasicTypeEnum<'l> {
         match node {
-            MirType::Integer32(_) => self.context.i32_type().into(),
-            MirType::Bool(_) => self.context.bool_type().into(),
-            MirType::Pointer(_) => self.context.ptr_type(AddressSpace::default()).into(),
-            MirType::Function(_) | MirType::Void(_) => unimplemented!("cannot lower this type"),
+            MirTy::Integer32(_) => self.context.i32_type().into(),
+            MirTy::Bool(_) => self.context.bool_type().into(),
+            MirTy::Pointer(_) => self.context.ptr_type(AddressSpace::default()).into(),
+            MirTy::Function(_) | MirTy::Void(_) => unimplemented!("cannot lower this type"),
         }
     }
 }

--- a/compiler/eight-middle/src/context.rs
+++ b/compiler/eight-middle/src/context.rs
@@ -4,7 +4,7 @@ use crate::hir::{
 };
 use crate::intern::{StringInterner, TypedInterner};
 use crate::mir::{
-    MirBoolType, MirFunctionType, MirInteger32Type, MirPointerType, MirType, MirTypeId, MirVoidType,
+    MirBoolType, MirFunctionType, MirInteger32Type, MirPointerType, MirTy, MirTyId, MirVoidType,
 };
 use bumpalo::Bump;
 use eight_span::Span;
@@ -14,7 +14,7 @@ use std::rc::Rc;
 pub struct CompileContext<'be> {
     allocator: Rc<Bump>,
     strings: StringInterner<'be>,
-    mir_types: TypedInterner<'be, MirTypeId, MirType<'be>>,
+    mir_types: TypedInterner<'be, MirTyId, MirTy<'be>>,
     hir_types: TypedInterner<'be, HirTyId, HirTy<'be>>,
 }
 
@@ -125,42 +125,42 @@ impl<'be> CompileContext<'be> {
 }
 
 impl<'be> CompileContext<'be> {
-    pub fn mir_i32_type(&'be self) -> &'be MirType<'be> {
-        let id = MirTypeId::compute_i32_type_id();
+    pub fn mir_i32_type(&'be self) -> &'be MirTy<'be> {
+        let id = MirTyId::compute_i32_type_id();
         self.mir_types
-            .get_interned(id, MirType::Integer32(MirInteger32Type))
+            .get_interned(id, MirTy::Integer32(MirInteger32Type))
     }
 
-    pub fn mir_bool_type(&'be self) -> &'be MirType<'be> {
-        let id = MirTypeId::compute_bool_type_id();
-        self.mir_types.get_interned(id, MirType::Bool(MirBoolType))
+    pub fn mir_bool_type(&'be self) -> &'be MirTy<'be> {
+        let id = MirTyId::compute_bool_type_id();
+        self.mir_types.get_interned(id, MirTy::Bool(MirBoolType))
     }
 
-    pub fn mir_void_type(&'be self) -> &'be MirType<'be> {
-        let id = MirTypeId::compute_void_type_id();
-        self.mir_types.get_interned(id, MirType::Void(MirVoidType))
+    pub fn mir_void_type(&'be self) -> &'be MirTy<'be> {
+        let id = MirTyId::compute_void_type_id();
+        self.mir_types.get_interned(id, MirTy::Void(MirVoidType))
     }
 
-    pub fn mir_pointer_type(&'be self) -> &'be MirType<'be> {
-        let id = MirTypeId::compute_pointer_type_id();
+    pub fn mir_pointer_type(&'be self) -> &'be MirTy<'be> {
+        let id = MirTyId::compute_pointer_type_id();
         self.mir_types
-            .get_interned(id, MirType::Pointer(MirPointerType {}))
+            .get_interned(id, MirTy::Pointer(MirPointerType {}))
     }
 
     pub fn mir_function_type(
         &'be self,
-        return_type: &'be MirType<'be>,
-        parameters: Vec<&'be MirType<'be>>,
-    ) -> &'be MirType<'be> {
-        let return_type_id = MirTypeId::from(return_type);
+        return_type: &'be MirTy<'be>,
+        parameters: Vec<&'be MirTy<'be>>,
+    ) -> &'be MirTy<'be> {
+        let return_type_id = MirTyId::from(return_type);
         let parameters_ids = parameters
             .iter()
-            .map(|ty| MirTypeId::from(*ty))
+            .map(|ty| MirTyId::from(*ty))
             .collect::<Vec<_>>();
-        let id = MirTypeId::compute_function_type_id(&return_type_id, parameters_ids.as_slice());
+        let id = MirTyId::compute_function_type_id(&return_type_id, parameters_ids.as_slice());
         self.mir_types.get_interned(
             id,
-            MirType::Function(MirFunctionType {
+            MirTy::Function(MirFunctionType {
                 return_type,
                 parameters,
             }),

--- a/compiler/eight-middle/src/hir_lowering_pass/mod.rs
+++ b/compiler/eight-middle/src/hir_lowering_pass/mod.rs
@@ -6,7 +6,7 @@ use crate::hir::{HirCallableReferenceExpr, HirCallableSymbol, HirModule};
 use crate::hir::{HirExprStmt, HirFunction, HirLetStmt, HirStmt};
 use crate::hir::{HirGroupExpr, HirTy};
 use crate::mir::MirModule;
-use crate::mir::MirType;
+use crate::mir::MirTy;
 use crate::mir::MirValueId;
 use crate::mir_builder::{MirFunctionBuilder, MirModuleContext};
 use crate::mir_error::MirResult;
@@ -41,7 +41,7 @@ impl<'hir, 'mir> MirModuleLoweringPass<'mir> {
                 .iter()
                 .map(|p| self.visit_ty(p.ty))
                 .collect::<MirResult<Vec<_>>>()?;
-            let MirType::Function(ty) = self.cc.mir_function_type(return_type, parameters) else {
+            let MirTy::Function(ty) = self.cc.mir_function_type(return_type, parameters) else {
                 ice!("didnt get function type from arena");
             };
             let name = self.cc.intern_str(function.name);
@@ -220,7 +220,7 @@ impl<'hir, 'mir> MirModuleLoweringPass<'mir> {
         let value_ty = b.data().get_value_type(*id);
         let expected_ty = self.visit_ty(expr.ty)?;
         // If it is a pointer type, we automatically dereference it.
-        if let MirType::Pointer(_) = value_ty {
+        if let MirTy::Pointer(_) = value_ty {
             let load = b.build_load(cx, *id, expected_ty, None);
             return Ok(load);
         }
@@ -280,7 +280,7 @@ impl<'hir, 'mir> MirModuleLoweringPass<'mir> {
     ///
     /// The type system in MIR is substantially smaller and simpler than the language and HIR. This
     /// means we can do a lot of shortcutting here.
-    pub fn visit_ty(&self, node: &'hir HirTy<'hir>) -> MirResult<&'mir MirType<'mir>> {
+    pub fn visit_ty(&self, node: &'hir HirTy<'hir>) -> MirResult<&'mir MirTy<'mir>> {
         match node {
             HirTy::Integer32(_) => Ok(self.cc.mir_i32_type()),
             HirTy::Boolean(_) => Ok(self.cc.mir_bool_type()),

--- a/compiler/eight-middle/src/mir.rs
+++ b/compiler/eight-middle/src/mir.rs
@@ -56,9 +56,9 @@ impl<'mir> MirModule<'mir> {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub struct MirTypeId(u64);
+pub struct MirTyId(u64);
 
-impl MirTypeId {
+impl MirTyId {
     pub fn compute_i32_type_id() -> Self {
         let mut hasher = DefaultHasher::new();
         0x00.hash(&mut hasher);
@@ -77,7 +77,7 @@ impl MirTypeId {
         Self(hasher.finish())
     }
 
-    pub fn compute_function_type_id(return_type: &MirTypeId, parameters: &[MirTypeId]) -> Self {
+    pub fn compute_function_type_id(return_type: &MirTyId, parameters: &[MirTyId]) -> Self {
         let mut hasher = DefaultHasher::new();
         (0x10, return_type, parameters).hash(&mut hasher);
         Self(hasher.finish())
@@ -90,21 +90,21 @@ impl MirTypeId {
     }
 }
 
-impl<'mir> From<&'mir MirType<'mir>> for MirTypeId {
-    fn from(ty: &'mir MirType<'mir>) -> Self {
+impl<'mir> From<&'mir MirTy<'mir>> for MirTyId {
+    fn from(ty: &'mir MirTy<'mir>) -> Self {
         match ty {
-            MirType::Integer32(_) => MirTypeId::compute_i32_type_id(),
-            MirType::Bool(_) => MirTypeId::compute_bool_type_id(),
-            MirType::Void(_) => MirTypeId::compute_void_type_id(),
-            MirType::Pointer(_) => MirTypeId::compute_pointer_type_id(),
-            MirType::Function(ty) => {
+            MirTy::Integer32(_) => MirTyId::compute_i32_type_id(),
+            MirTy::Bool(_) => MirTyId::compute_bool_type_id(),
+            MirTy::Void(_) => MirTyId::compute_void_type_id(),
+            MirTy::Pointer(_) => MirTyId::compute_pointer_type_id(),
+            MirTy::Function(ty) => {
                 let parameters = ty
                     .parameters
                     .iter()
-                    .map(|p| MirTypeId::from(*p))
+                    .map(|p| MirTyId::from(*p))
                     .collect::<Vec<_>>();
-                MirTypeId::compute_function_type_id(
-                    &MirTypeId::from(ty.return_type),
+                MirTyId::compute_function_type_id(
+                    &MirTyId::from(ty.return_type),
                     parameters.as_slice(),
                 )
             }
@@ -113,7 +113,7 @@ impl<'mir> From<&'mir MirType<'mir>> for MirTypeId {
 }
 
 #[derive(Debug, Hash, PartialEq, Eq)]
-pub enum MirType<'mir> {
+pub enum MirTy<'mir> {
     Integer32(MirInteger32Type),
     Bool(MirBoolType),
     Void(MirVoidType),
@@ -121,18 +121,18 @@ pub enum MirType<'mir> {
     Function(MirFunctionType<'mir>),
 }
 
-impl MirType<'_> {
+impl MirTy<'_> {
     /// Get the size of the type in bytes.
     ///
     /// This is currently hard-coded for x86-64 and will need to be populated with target info once
     /// that has been added.
     pub fn get_size(&self) -> usize {
         match self {
-            MirType::Integer32(_) => 32,
-            MirType::Bool(_) => 1,
-            MirType::Void(_) => 0,
-            MirType::Pointer(_) => 64,
-            MirType::Function(_) => unimplemented!(),
+            MirTy::Integer32(_) => 32,
+            MirTy::Bool(_) => 1,
+            MirTy::Void(_) => 0,
+            MirTy::Pointer(_) => 64,
+            MirTy::Function(_) => unimplemented!(),
         }
     }
 }
@@ -151,8 +151,8 @@ pub struct MirPointerType;
 
 #[derive(Debug, Hash, PartialEq, Eq)]
 pub struct MirFunctionType<'mir> {
-    pub return_type: &'mir MirType<'mir>,
-    pub parameters: Vec<&'mir MirType<'mir>>,
+    pub return_type: &'mir MirTy<'mir>,
+    pub parameters: Vec<&'mir MirTy<'mir>>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Ord, PartialOrd)]
@@ -174,14 +174,14 @@ pub enum MirValue<'mir> {
 #[derive(Debug)]
 pub struct MirConstantInteger32<'mir> {
     pub value_id: MirValueId,
-    pub ty: &'mir MirType<'mir>,
+    pub ty: &'mir MirTy<'mir>,
     pub value: i32,
 }
 
 #[derive(Debug)]
 pub struct MirConstantBool<'mir> {
     pub value_id: MirValueId,
-    pub ty: &'mir MirType<'mir>,
+    pub ty: &'mir MirTy<'mir>,
     pub value: bool,
 }
 
@@ -189,7 +189,7 @@ pub struct MirConstantBool<'mir> {
 pub struct MirArgument<'mir> {
     pub value_id: MirValueId,
     pub name: &'mir str,
-    pub ty: &'mir MirType<'mir>,
+    pub ty: &'mir MirTy<'mir>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Ord, PartialOrd)]
@@ -217,7 +217,7 @@ pub enum MirInstruction<'mir> {
 }
 
 impl<'mir> MirInstruction<'mir> {
-    pub fn ty(&self) -> &'mir MirType<'mir> {
+    pub fn ty(&self) -> &'mir MirTy<'mir> {
         match self {
             MirInstruction::Alloca(i) => i.ty,
             MirInstruction::Load(i) => i.ty,
@@ -239,9 +239,9 @@ pub struct MirAllocaInstruction<'mir> {
     pub value_id: MirValueId,
     pub name: &'mir str,
     /// The type of the instruction itself. This is always the opaque pointer type for `mem.alloca`.
-    pub ty: &'mir MirType<'mir>,
+    pub ty: &'mir MirTy<'mir>,
     /// The number (in bits) to allocate.
-    pub alloc_ty: &'mir MirType<'mir>,
+    pub alloc_ty: &'mir MirTy<'mir>,
 }
 
 /// The `mem.load` instruction.
@@ -251,7 +251,7 @@ pub struct MirLoadInstruction<'mir> {
     pub inst_id: MirInstructionId,
     pub name: &'mir str,
     /// The type being loaded
-    pub ty: &'mir MirType<'mir>,
+    pub ty: &'mir MirTy<'mir>,
     pub src: MirValueId,
 }
 
@@ -262,9 +262,9 @@ pub struct MirStoreInstruction<'mir> {
     pub name: &'mir str,
     pub value: MirValueId,
     /// The result of a store is always void
-    pub ty: &'mir MirType<'mir>,
+    pub ty: &'mir MirTy<'mir>,
     pub dest: MirValueId,
-    pub dest_ty: &'mir MirType<'mir>,
+    pub dest_ty: &'mir MirTy<'mir>,
 }
 
 /// The `fn.call` instruction.
@@ -276,7 +276,7 @@ pub struct MirCallInstruction<'mir> {
     pub callee: MirValueId,
     pub arguments: Vec<MirValueId>,
     /// The return type of the function.
-    pub ty: &'mir MirType<'mir>,
+    pub ty: &'mir MirTy<'mir>,
 }
 
 /// The `arith.add` instruction.
@@ -293,7 +293,7 @@ pub struct MirAddInstruction<'mir> {
     pub name: &'mir str,
     pub lhs: MirValueId,
     pub rhs: MirValueId,
-    pub ty: &'mir MirType<'mir>,
+    pub ty: &'mir MirTy<'mir>,
 }
 
 /// The `arith.sub` instruction.
@@ -306,7 +306,7 @@ pub struct MirSubInstruction<'mir> {
     pub name: &'mir str,
     pub lhs: MirValueId,
     pub rhs: MirValueId,
-    pub ty: &'mir MirType<'mir>,
+    pub ty: &'mir MirTy<'mir>,
 }
 
 /// The `arith.mul` instruction.
@@ -319,7 +319,7 @@ pub struct MirMulInstruction<'mir> {
     pub name: &'mir str,
     pub lhs: MirValueId,
     pub rhs: MirValueId,
-    pub ty: &'mir MirType<'mir>,
+    pub ty: &'mir MirTy<'mir>,
 }
 
 /// The `arith.div` instruction.
@@ -332,7 +332,7 @@ pub struct MirDivInstruction<'mir> {
     pub name: &'mir str,
     pub lhs: MirValueId,
     pub rhs: MirValueId,
-    pub ty: &'mir MirType<'mir>,
+    pub ty: &'mir MirTy<'mir>,
 }
 
 /// The `ptr.add` instruction.
@@ -344,7 +344,7 @@ pub struct MirPtrAddInstruction<'mir> {
     pub inst_id: MirInstructionId,
     pub value_id: MirValueId,
     pub name: &'mir str,
-    pub ty: &'mir MirType<'mir>,
+    pub ty: &'mir MirTy<'mir>,
     pub ptr: MirValueId,
     pub offset: MirValueId,
 }
@@ -369,7 +369,7 @@ impl<'mir> MirFunctionData<'mir> {
     }
 
     /// Get the type the instruction evaluates to.
-    pub fn get_instruction_type(&self, id: MirInstructionId) -> &'mir MirType<'mir> {
+    pub fn get_instruction_type(&self, id: MirInstructionId) -> &'mir MirTy<'mir> {
         self.get_instruction(id).ty()
     }
 
@@ -398,7 +398,7 @@ impl<'mir> MirFunctionData<'mir> {
     /// Get the type of the value with the given id.
     ///
     /// This function panics if the value does not exist.
-    pub fn get_value_type(&self, id: MirValueId) -> &'mir MirType<'mir> {
+    pub fn get_value_type(&self, id: MirValueId) -> &'mir MirTy<'mir> {
         match self.get_value(id) {
             MirValue::ConstantInteger32(i) => i.ty,
             MirValue::ConstantBool(i) => i.ty,

--- a/compiler/eight-middle/src/mir_builder.rs
+++ b/compiler/eight-middle/src/mir_builder.rs
@@ -5,7 +5,7 @@ use crate::mir::{
     MirCallInstruction, MirConstantBool, MirConstantInteger32, MirDivInstruction, MirFunction,
     MirFunctionData, MirFunctionId, MirFunctionType, MirInstruction, MirInstructionId,
     MirLoadInstruction, MirModule, MirModuleData, MirMulInstruction, MirPtrAddInstruction,
-    MirStoreInstruction, MirSubInstruction, MirType, MirValue, MirValueId,
+    MirStoreInstruction, MirSubInstruction, MirTy, MirValue, MirValueId,
 };
 use eight_diagnostics::ice;
 pub struct MirModuleContext<'mir, 'hir> {
@@ -189,7 +189,7 @@ impl<'mir> MirFunctionBuilder<'mir> {
 
 impl<'mir> MirFunctionBuilder<'mir> {
     /// Build a constant integer value.
-    pub fn build_constant_integer32(&mut self, value: i32, ty: &'mir MirType<'mir>) -> MirValueId {
+    pub fn build_constant_integer32(&mut self, value: i32, ty: &'mir MirTy<'mir>) -> MirValueId {
         let value_id = self.get_next_value_id();
         let inst = MirValue::ConstantInteger32(MirConstantInteger32 {
             value_id,
@@ -199,7 +199,7 @@ impl<'mir> MirFunctionBuilder<'mir> {
         self.build_value(value_id, inst)
     }
 
-    pub fn build_constant_bool(&mut self, value: bool, ty: &'mir MirType<'mir>) -> MirValueId {
+    pub fn build_constant_bool(&mut self, value: bool, ty: &'mir MirTy<'mir>) -> MirValueId {
         let value_id = self.get_next_value_id();
         let inst = MirValue::ConstantBool(MirConstantBool {
             value_id,
@@ -210,7 +210,7 @@ impl<'mir> MirFunctionBuilder<'mir> {
     }
 
     /// Build an argument value
-    pub fn build_argument(&mut self, name: &'mir str, ty: &'mir MirType<'mir>) -> MirValueId {
+    pub fn build_argument(&mut self, name: &'mir str, ty: &'mir MirTy<'mir>) -> MirValueId {
         let value_id = self.get_next_value_id();
         let inst = MirValue::Argument(MirArgument { value_id, name, ty });
         self.build_value(value_id, inst)
@@ -227,7 +227,7 @@ impl<'mir> MirFunctionBuilder<'mir> {
     pub fn build_alloca<'hir>(
         &mut self,
         _: &MirModuleContext<'mir, 'hir>,
-        ty: &'mir MirType<'mir>,
+        ty: &'mir MirTy<'mir>,
         name: Option<&'mir str>,
     ) -> MirValueId {
         let inst_id = self.get_next_instruction_id();
@@ -272,7 +272,7 @@ impl<'mir> MirFunctionBuilder<'mir> {
         &mut self,
         _: &MirModuleContext<'mir, 'hir>,
         src: MirValueId,
-        ty: &'mir MirType<'mir>,
+        ty: &'mir MirTy<'mir>,
         name: Option<&'mir str>,
     ) -> MirValueId {
         let inst_id = self.get_next_instruction_id();
@@ -295,7 +295,7 @@ impl<'mir> MirFunctionBuilder<'mir> {
         _: &MirModuleContext<'mir, 'hir>,
         callee: MirValueId,
         arguments: Vec<MirValueId>,
-        return_ty: &'mir MirType<'mir>,
+        return_ty: &'mir MirTy<'mir>,
         name: Option<&'mir str>,
     ) -> MirValueId {
         let inst_id = self.get_next_instruction_id();
@@ -319,7 +319,7 @@ impl<'mir> MirFunctionBuilder<'mir> {
         _: &MirModuleContext<'mir, 'hir>,
         lhs: MirValueId,
         rhs: MirValueId,
-        ty: &'mir MirType<'mir>,
+        ty: &'mir MirTy<'mir>,
         name: Option<&'mir str>,
     ) -> MirValueId {
         let inst_id = self.get_next_instruction_id();
@@ -343,7 +343,7 @@ impl<'mir> MirFunctionBuilder<'mir> {
         _: &MirModuleContext<'mir, 'hir>,
         lhs: MirValueId,
         rhs: MirValueId,
-        ty: &'mir MirType<'mir>,
+        ty: &'mir MirTy<'mir>,
         name: Option<&'mir str>,
     ) -> MirValueId {
         let inst_id = self.get_next_instruction_id();
@@ -367,7 +367,7 @@ impl<'mir> MirFunctionBuilder<'mir> {
         _: &MirModuleContext<'mir, 'hir>,
         lhs: MirValueId,
         rhs: MirValueId,
-        ty: &'mir MirType<'mir>,
+        ty: &'mir MirTy<'mir>,
         name: Option<&'mir str>,
     ) -> MirValueId {
         let inst_id = self.get_next_instruction_id();
@@ -391,7 +391,7 @@ impl<'mir> MirFunctionBuilder<'mir> {
         _: &MirModuleContext<'mir, 'hir>,
         lhs: MirValueId,
         rhs: MirValueId,
-        ty: &'mir MirType<'mir>,
+        ty: &'mir MirTy<'mir>,
         name: Option<&'mir str>,
     ) -> MirValueId {
         let inst_id = self.get_next_instruction_id();

--- a/compiler/eight-middle/src/mir_textual_pass/mod.rs
+++ b/compiler/eight-middle/src/mir_textual_pass/mod.rs
@@ -3,7 +3,7 @@ use crate::mir::{
     MirAddInstruction, MirAllocaInstruction, MirCallInstruction, MirConstantBool,
     MirConstantInteger32, MirDivInstruction, MirFunction, MirFunctionData, MirFunctionId,
     MirInstruction, MirInstructionId, MirLoadInstruction, MirMulInstruction, MirPtrAddInstruction,
-    MirStoreInstruction, MirSubInstruction, MirType, MirValue,
+    MirStoreInstruction, MirSubInstruction, MirTy, MirValue,
 };
 use crate::mir::{MirModule, MirModuleData};
 use eight_diagnostics::ice;
@@ -402,13 +402,13 @@ impl<'a> MirModuleTextualPass<'a> {
         )
     }
 
-    pub fn visit_type<'mir: 'a>(&'a self, ty: &'mir MirType) -> DocBuilder<'a, Arena<'a>> {
+    pub fn visit_type<'mir: 'a>(&'a self, ty: &'mir MirTy) -> DocBuilder<'a, Arena<'a>> {
         match ty {
-            MirType::Integer32(_) => self.arena.text("i32"),
-            MirType::Bool(_) => self.arena.text("bool"),
-            MirType::Void(_) => self.arena.text("void"),
-            MirType::Pointer(_) => self.arena.text("ptr"),
-            MirType::Function(_) => unreachable!("should not print function types"),
+            MirTy::Integer32(_) => self.arena.text("i32"),
+            MirTy::Bool(_) => self.arena.text("bool"),
+            MirTy::Void(_) => self.arena.text("void"),
+            MirTy::Pointer(_) => self.arena.text("ptr"),
+            MirTy::Function(_) => unreachable!("should not print function types"),
         }
     }
 }


### PR DESCRIPTION
Renames MirType to MirTy in order to match HIR. Ideally MirType/HirType
would be ideal, but HirType is already used for intrinsic scalar types.
