### PR TITLE
build: include rust-analyzer and rust-src in rust toolchain

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -6,5 +6,7 @@ components = [
   "rustfmt",
   "clippy",
   "rust-std",
-  "rustc"
+  "rust-src",
+  "rustc",
+  "rust-analyzer",
 ]


### PR DESCRIPTION
This is necessary for Helix and other local tools to have LSP
functionality.
