### PR TITLE
refactor: inline callable reference expr into reference expr

### DIFF
--- a/compiler/eight-middle/src/ast_lowering_pass/mod.rs
+++ b/compiler/eight-middle/src/ast_lowering_pass/mod.rs
@@ -1,11 +1,11 @@
 use crate::context::CompileContext;
-use crate::hir::{HirCallableSymbol, HirTy};
 use crate::hir::{
     HirConstructExprArgument, HirExpr, HirExprStmt, HirFunction, HirFunctionParameterSignature,
     HirFunctionSignature, HirInstance, HirInstanceSignature, HirLetStmt, HirModule, HirModuleBody,
     HirModuleSignature, HirStmt, HirStruct, HirStructFieldSignature, HirStructSignature, HirTrait,
     HirTraitSignature, HirType, HirTypeParameterSignature, HirTypeSignature,
 };
+use crate::hir::{HirReferenceSymbol, HirTy};
 use crate::hir_builder::HirBuilder;
 use crate::scope::Scope;
 use crate::HirResult;
@@ -231,7 +231,7 @@ impl<'ast, 'hir> AstLoweringPass<'ast, 'hir> {
             AstUnaryOp::Neg => ("Neg", "neg"),
             _ => ice!("visit_unary_op called addressof or deref operator"),
         };
-        let sym = HirCallableSymbol::new_trait_function(
+        let symbol = HirReferenceSymbol::new_trait_function(
             trait_name,
             node.op_span,
             vec![],
@@ -239,14 +239,18 @@ impl<'ast, 'hir> AstLoweringPass<'ast, 'hir> {
             node.op_span,
             vec![],
         );
-        let callable_reference = HirBuilder::build_callable_reference_expr(
+        let reference = HirBuilder::build_reference_expr(
             node.span,
-            sym,
+            // TODO: This is a placeholder name. The node needs restructuring around this, as this
+            //  should not even be required to be here.
+            self.cc.intern_str("__placeholder__"),
+            node.operand.span(),
             self.cc.hir_uninitialized_type(),
+            symbol,
         );
         Ok(HirExpr::Call(HirBuilder::build_call_expr(
             node.span,
-            HirExpr::CallableReference(callable_reference),
+            HirExpr::Reference(reference),
             vec![self.visit_expr(node.operand)?],
             // There are no explicit type arguments provided, besides, as we mentioned above, there
             // are no type parameters on these trait functions.
@@ -275,7 +279,7 @@ impl<'ast, 'hir> AstLoweringPass<'ast, 'hir> {
             AstBinaryOp::And => ("And", "and"),
             AstBinaryOp::Or => ("Or", "or"),
         };
-        let sym = HirCallableSymbol::new_trait_function(
+        let symbol = HirReferenceSymbol::new_trait_function(
             trait_name,
             node.op_span,
             vec![],
@@ -283,14 +287,18 @@ impl<'ast, 'hir> AstLoweringPass<'ast, 'hir> {
             node.op_span,
             vec![],
         );
-        let callable_reference = HirBuilder::build_callable_reference_expr(
+        let reference = HirBuilder::build_reference_expr(
             node.span,
-            sym,
+            // TODO: This is a placeholder name. The node needs restructuring around this, as this
+            //  should not even be required to be here.
+            self.cc.intern_str("__placeholder__"),
+            node.lhs.span(),
             self.cc.hir_uninitialized_type(),
+            symbol,
         );
         Ok(HirExpr::Call(HirBuilder::build_call_expr(
             node.span,
-            HirExpr::CallableReference(callable_reference),
+            HirExpr::Reference(reference),
             vec![self.visit_expr(node.lhs)?, self.visit_expr(node.rhs)?],
             // There are no explicit type arguments provided, besides, as we mentioned above, there
             // are no type parameters on these trait functions.
@@ -336,6 +344,9 @@ impl<'ast, 'hir> AstLoweringPass<'ast, 'hir> {
             self.cc.intern_str(&node.name.name),
             node.name.span,
             self.cc.hir_uninitialized_type(),
+            // Assume that it is a local reference by default. The value here does not really matter
+            // as the type checker will replace this as it sees fit.
+            HirReferenceSymbol::Local,
         )))
     }
 

--- a/compiler/eight-middle/src/ast_lowering_pass/mod.rs
+++ b/compiler/eight-middle/src/ast_lowering_pass/mod.rs
@@ -1,9 +1,10 @@
 use crate::context::CompileContext;
 use crate::hir::{
     HirConstructExprArgument, HirExpr, HirExprStmt, HirFunction, HirFunctionParameterSignature,
-    HirFunctionSignature, HirInstance, HirInstanceSignature, HirLetStmt, HirModule, HirModuleBody,
-    HirModuleSignature, HirStmt, HirStruct, HirStructFieldSignature, HirStructSignature, HirTrait,
-    HirTraitSignature, HirType, HirTypeParameterSignature, HirTypeSignature,
+    HirFunctionSignature, HirInstance, HirInstanceSignature, HirLetStmt, HirLocalReferenceSymbol,
+    HirModule, HirModuleBody, HirModuleSignature, HirStmt, HirStruct, HirStructFieldSignature,
+    HirStructSignature, HirTrait, HirTraitSignature, HirType, HirTypeParameterSignature,
+    HirTypeSignature,
 };
 use crate::hir::{HirReferenceSymbol, HirTy};
 use crate::hir_builder::HirBuilder;
@@ -239,15 +240,8 @@ impl<'ast, 'hir> AstLoweringPass<'ast, 'hir> {
             node.op_span,
             vec![],
         );
-        let reference = HirBuilder::build_reference_expr(
-            node.span,
-            // TODO: This is a placeholder name. The node needs restructuring around this, as this
-            //  should not even be required to be here.
-            self.cc.intern_str("__placeholder__"),
-            node.operand.span(),
-            self.cc.hir_uninitialized_type(),
-            symbol,
-        );
+        let reference =
+            HirBuilder::build_reference_expr(node.span, self.cc.hir_uninitialized_type(), symbol);
         Ok(HirExpr::Call(HirBuilder::build_call_expr(
             node.span,
             HirExpr::Reference(reference),
@@ -287,15 +281,8 @@ impl<'ast, 'hir> AstLoweringPass<'ast, 'hir> {
             node.op_span,
             vec![],
         );
-        let reference = HirBuilder::build_reference_expr(
-            node.span,
-            // TODO: This is a placeholder name. The node needs restructuring around this, as this
-            //  should not even be required to be here.
-            self.cc.intern_str("__placeholder__"),
-            node.lhs.span(),
-            self.cc.hir_uninitialized_type(),
-            symbol,
-        );
+        let reference =
+            HirBuilder::build_reference_expr(node.span, self.cc.hir_uninitialized_type(), symbol);
         Ok(HirExpr::Call(HirBuilder::build_call_expr(
             node.span,
             HirExpr::Reference(reference),
@@ -341,12 +328,13 @@ impl<'ast, 'hir> AstLoweringPass<'ast, 'hir> {
     ) -> HirResult<HirExpr<'hir>> {
         Ok(HirExpr::Reference(HirBuilder::build_reference_expr(
             node.span,
-            self.cc.intern_str(&node.name.name),
-            node.name.span,
             self.cc.hir_uninitialized_type(),
             // Assume that it is a local reference by default. The value here does not really matter
             // as the type checker will replace this as it sees fit.
-            HirReferenceSymbol::Local,
+            HirReferenceSymbol::Local(HirLocalReferenceSymbol {
+                name: self.cc.intern_str(&node.name.name),
+                name_span: node.name.span,
+            }),
         )))
     }
 

--- a/compiler/eight-middle/src/builtin.rs
+++ b/compiler/eight-middle/src/builtin.rs
@@ -12,7 +12,7 @@ use std::fmt::Display;
 /// implemented as compiler intrinsics, and lowered into instructions like `arith.add` instead of
 /// function calls.
 #[derive(Debug)]
-pub enum CompilerBuiltin {
+pub enum CompilerIntrinsic {
     IntegerAdd,
     IntegerSub,
     IntegerMul,
@@ -24,8 +24,6 @@ pub enum CompilerBuiltin {
     IntegerGt,
     IntegerLte,
     IntegerGte,
-    IntegerAnd,
-    IntegerOr,
     BooleanAnd,
     BooleanOr,
     BooleanEq,
@@ -34,30 +32,28 @@ pub enum CompilerBuiltin {
     BooleanNot,
 }
 
-impl Display for CompilerBuiltin {
+impl Display for CompilerIntrinsic {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             // Compiler intrinsics for the i32 type.
-            CompilerBuiltin::IntegerAdd => write!(f, "@@builtin_i32_add"),
-            CompilerBuiltin::IntegerSub => write!(f, "@@builtin_i32_sub"),
-            CompilerBuiltin::IntegerMul => write!(f, "@@builtin_i32_mul"),
-            CompilerBuiltin::IntegerDiv => write!(f, "@@builtin_i32_div"),
-            CompilerBuiltin::IntegerRem => write!(f, "@@builtin_i32_rem"),
-            CompilerBuiltin::IntegerEq => write!(f, "@@builtin_i32_eq"),
-            CompilerBuiltin::IntegerNeq => write!(f, "@@builtin_i32_neq"),
-            CompilerBuiltin::IntegerLt => write!(f, "@builtin_i32_lt"),
-            CompilerBuiltin::IntegerGt => write!(f, "@@builtin_i32_gt"),
-            CompilerBuiltin::IntegerLte => write!(f, "@@builtin_i32_lte"),
-            CompilerBuiltin::IntegerGte => write!(f, "@@builtin_i32_gte"),
-            CompilerBuiltin::IntegerAnd => write!(f, "@@builtin_i32_and"),
-            CompilerBuiltin::IntegerOr => write!(f, "@@builtin_i32_or"),
-            CompilerBuiltin::IntegerNeg => write!(f, "@@builtin_i32_neg"),
+            CompilerIntrinsic::IntegerAdd => write!(f, "@@builtin_i32_add"),
+            CompilerIntrinsic::IntegerSub => write!(f, "@@builtin_i32_sub"),
+            CompilerIntrinsic::IntegerMul => write!(f, "@@builtin_i32_mul"),
+            CompilerIntrinsic::IntegerDiv => write!(f, "@@builtin_i32_div"),
+            CompilerIntrinsic::IntegerRem => write!(f, "@@builtin_i32_rem"),
+            CompilerIntrinsic::IntegerEq => write!(f, "@@builtin_i32_eq"),
+            CompilerIntrinsic::IntegerNeq => write!(f, "@@builtin_i32_neq"),
+            CompilerIntrinsic::IntegerLt => write!(f, "@builtin_i32_lt"),
+            CompilerIntrinsic::IntegerGt => write!(f, "@@builtin_i32_gt"),
+            CompilerIntrinsic::IntegerLte => write!(f, "@@builtin_i32_lte"),
+            CompilerIntrinsic::IntegerGte => write!(f, "@@builtin_i32_gte"),
+            CompilerIntrinsic::IntegerNeg => write!(f, "@@builtin_i32_neg"),
             // Compiler intrinsics for the bool type.
-            CompilerBuiltin::BooleanAnd => write!(f, "@@builtin_bool_and"),
-            CompilerBuiltin::BooleanOr => write!(f, "@@builtin_bool_or"),
-            CompilerBuiltin::BooleanNot => write!(f, "@@builtin_bool_not"),
-            CompilerBuiltin::BooleanEq => write!(f, "@@builtin_bool_eq"),
-            CompilerBuiltin::BooleanNeq => write!(f, "@@builtin_bool_neq"),
+            CompilerIntrinsic::BooleanAnd => write!(f, "@@builtin_bool_and"),
+            CompilerIntrinsic::BooleanOr => write!(f, "@@builtin_bool_or"),
+            CompilerIntrinsic::BooleanNot => write!(f, "@@builtin_bool_not"),
+            CompilerIntrinsic::BooleanEq => write!(f, "@@builtin_bool_eq"),
+            CompilerIntrinsic::BooleanNeq => write!(f, "@@builtin_bool_neq"),
         }
     }
 }

--- a/compiler/eight-middle/src/hir.rs
+++ b/compiler/eight-middle/src/hir.rs
@@ -1,5 +1,6 @@
 //! The High-level Intermediate Representation.
 
+use crate::builtin::CompilerIntrinsic;
 use crate::LinkageType;
 use eight_diagnostics::ice;
 use eight_span::Span;
@@ -111,6 +112,38 @@ pub struct HirCallableReferenceExpr<'hir> {
     pub ty: &'hir HirTy<'hir>,
 }
 
+impl HirCallableSymbol<'_> {
+    /// Try to convert this callable reference into a compiler intrinsic.
+    #[rustfmt::skip]
+    pub fn get_compiler_intrinsic_candidate(&self) -> Option<CompilerIntrinsic> {
+        let HirCallableSymbol::TraitFunction(symbol) = self else {
+            return None
+        };
+        match (symbol.trait_name, symbol.method_name, symbol.method_type_arguments.as_slice()) {
+            // Compiler intrinsics for the i32 type
+            ("Add", "add", &[HirTy::Integer32(_), HirTy::Integer32(_), HirTy::Integer32(_)]) => Some(CompilerIntrinsic::IntegerAdd),
+            ("Sub", "sub", &[HirTy::Integer32(_), HirTy::Integer32(_), HirTy::Integer32(_)]) => Some(CompilerIntrinsic::IntegerSub),
+            ("Mul", "mul", &[HirTy::Integer32(_), HirTy::Integer32(_), HirTy::Integer32(_)]) => Some(CompilerIntrinsic::IntegerMul),
+            ("Div", "div", &[HirTy::Integer32(_), HirTy::Integer32(_), HirTy::Integer32(_)]) => Some(CompilerIntrinsic::IntegerDiv),
+            ("Rem", "rem", &[HirTy::Integer32(_), HirTy::Integer32(_), HirTy::Integer32(_)]) => Some(CompilerIntrinsic::IntegerRem),
+            ("Eq", "eq", &[HirTy::Integer32(_), HirTy::Integer32(_)]) => Some(CompilerIntrinsic::IntegerEq),
+            ("Eq", "neq", &[HirTy::Integer32(_), HirTy::Integer32(_)]) => Some(CompilerIntrinsic::IntegerNeq),
+            ("Ord", "lt", &[HirTy::Integer32(_), HirTy::Integer32(_)]) => Some(CompilerIntrinsic::IntegerLt),
+            ("Ord", "gt", &[HirTy::Integer32(_), HirTy::Integer32(_)]) => Some(CompilerIntrinsic::IntegerGt),
+            ("Ord", "le", &[HirTy::Integer32(_), HirTy::Integer32(_)]) => Some(CompilerIntrinsic::IntegerLte),
+            ("Ord", "ge", &[HirTy::Integer32(_), HirTy::Integer32(_)]) => Some(CompilerIntrinsic::IntegerGte),
+            ("Neg", "neg", &[HirTy::Integer32(_)]) => Some(CompilerIntrinsic::IntegerNeg),
+            // Compiler intrinsics for the bool type
+            ("Not", "not", &[HirTy::Boolean(_)]) => Some(CompilerIntrinsic::BooleanNot),
+            ("Eq", "eq", &[HirTy::Boolean(_), HirTy::Boolean(_)]) => Some(CompilerIntrinsic::BooleanEq),
+            ("Eq", "neq", &[HirTy::Boolean(_), HirTy::Boolean(_)]) => Some(CompilerIntrinsic::BooleanNeq),
+            ("And", "and", &[HirTy::Boolean(_), HirTy::Boolean(_)]) => Some(CompilerIntrinsic::BooleanAnd),
+            ("Or", "or", &[HirTy::Boolean(_), HirTy::Boolean(_)]) => Some(CompilerIntrinsic::BooleanOr),
+            _ => None
+        }
+    }
+}
+
 /// A reference to a callable symbol.
 ///
 /// A callable symbol is a function or a trait instance's implementation of a trait function. This
@@ -121,15 +154,7 @@ pub struct HirCallableReferenceExpr<'hir> {
 pub enum HirCallableSymbol<'hir> {
     Function(HirFunctionCallableSymbol<'hir>),
     TraitFunction(HirTraitFunctionCallableSymbol<'hir>),
-}
-
-impl<'hir> HirCallableSymbol<'hir> {
-    pub fn instantiated_call_parameters(&self) -> &[&'hir HirTy<'hir>] {
-        match self {
-            HirCallableSymbol::Function(sym) => sym.instantiated_call_parameters.as_slice(),
-            HirCallableSymbol::TraitFunction(sym) => sym.instantiated_call_parameters.as_slice(),
-        }
-    }
+    Intrinsic(CompilerIntrinsic),
 }
 
 #[derive(Debug)]
@@ -244,6 +269,14 @@ pub struct HirConstructExprArgument<'hir> {
 pub struct HirGroupExpr<'hir> {
     pub span: Span,
     pub inner: Box<HirExpr<'hir>>,
+    pub ty: &'hir HirTy<'hir>,
+}
+
+#[derive(Debug)]
+pub struct HirIntrinsicCallExpr<'hir> {
+    pub span: Span,
+    pub callee: CompilerIntrinsic,
+    pub arguments: Vec<HirExpr<'hir>>,
     pub ty: &'hir HirTy<'hir>,
 }
 

--- a/compiler/eight-middle/src/hir.rs
+++ b/compiler/eight-middle/src/hir.rs
@@ -96,8 +96,6 @@ pub struct HirDerefExpr<'hir> {
 #[derive(Debug)]
 pub struct HirReferenceExpr<'hir> {
     pub span: Span,
-    pub name: &'hir str,
-    pub name_span: Span,
     /// The type of `name` in the current scope.
     pub ty: &'hir HirTy<'hir>,
     pub kind: HirReferenceSymbol<'hir>,
@@ -148,10 +146,16 @@ impl HirReferenceSymbol<'_> {
 /// requiring to have an undecided variant.
 #[derive(Debug)]
 pub enum HirReferenceSymbol<'hir> {
-    Local,
+    Local(HirLocalReferenceSymbol<'hir>),
     Function(HirFunctionReferenceSymbol<'hir>),
     TraitMethod(HirTraitMethodReferenceSymbol<'hir>),
     Intrinsic(CompilerIntrinsic),
+}
+
+#[derive(Debug)]
+pub struct HirLocalReferenceSymbol<'hir> {
+    pub name: &'hir str,
+    pub name_span: Span,
 }
 
 #[derive(Debug)]

--- a/compiler/eight-middle/src/hir.rs
+++ b/compiler/eight-middle/src/hir.rs
@@ -14,7 +14,6 @@ pub enum HirExpr<'hir> {
     BooleanLiteral(HirBooleanLiteralExpr<'hir>),
     Assign(HirAssignExpr<'hir>),
     Reference(HirReferenceExpr<'hir>),
-    CallableReference(HirCallableReferenceExpr<'hir>),
     ConstantIndex(HirConstantIndexExpr<'hir>),
     OffsetIndex(HirOffsetIndexExpr<'hir>),
     Call(HirCallExpr<'hir>),
@@ -36,7 +35,6 @@ impl<'hir> HirExpr<'hir> {
             HirExpr::Construct(e) => e.span,
             HirExpr::Group(e) => e.span,
             HirExpr::Reference(e) => e.span,
-            HirExpr::CallableReference(e) => e.span,
             HirExpr::AddressOf(e) => e.span,
             HirExpr::Deref(e) => e.span,
         }
@@ -53,7 +51,6 @@ impl<'hir> HirExpr<'hir> {
             HirExpr::Construct(e) => e.ty,
             HirExpr::Group(e) => e.ty,
             HirExpr::Reference(e) => e.ty,
-            HirExpr::CallableReference(e) => e.ty,
             HirExpr::AddressOf(e) => e.ty,
             HirExpr::Deref(e) => e.ty,
         }
@@ -103,20 +100,14 @@ pub struct HirReferenceExpr<'hir> {
     pub name_span: Span,
     /// The type of `name` in the current scope.
     pub ty: &'hir HirTy<'hir>,
+    pub kind: HirReferenceSymbol<'hir>,
 }
 
-#[derive(Debug)]
-pub struct HirCallableReferenceExpr<'hir> {
-    pub span: Span,
-    pub symbol: HirCallableSymbol<'hir>,
-    pub ty: &'hir HirTy<'hir>,
-}
-
-impl HirCallableSymbol<'_> {
+impl HirReferenceSymbol<'_> {
     /// Try to convert this callable reference into a compiler intrinsic.
     #[rustfmt::skip]
     pub fn get_compiler_intrinsic_candidate(&self) -> Option<CompilerIntrinsic> {
-        let HirCallableSymbol::TraitFunction(symbol) = self else {
+        let HirReferenceSymbol::TraitMethod(symbol) = self else {
             return None
         };
         match (symbol.trait_name, symbol.method_name, symbol.method_type_arguments.as_slice()) {
@@ -144,21 +135,27 @@ impl HirCallableSymbol<'_> {
     }
 }
 
-/// A reference to a callable symbol.
+/// A reference to a symbol.
 ///
-/// A callable symbol is a function or a trait instance's implementation of a trait function. This
-/// distinction from [`HirReferenceExpr`] is important because it allows us to distinguish between
-/// values in scope and function, as well as making the distinction between trait functions and
-/// regular functions.
+/// A reference can be resolved into one of four categories:
+///
+/// 1. Local variable
+/// 2. Global function
+/// 3. Trait method
+/// 4. Compiler intrinsic
+///
+/// References are assumed to be local until proven otherwise. This simplifies things a bit by not
+/// requiring to have an undecided variant.
 #[derive(Debug)]
-pub enum HirCallableSymbol<'hir> {
-    Function(HirFunctionCallableSymbol<'hir>),
-    TraitFunction(HirTraitFunctionCallableSymbol<'hir>),
+pub enum HirReferenceSymbol<'hir> {
+    Local,
+    Function(HirFunctionReferenceSymbol<'hir>),
+    TraitMethod(HirTraitMethodReferenceSymbol<'hir>),
     Intrinsic(CompilerIntrinsic),
 }
 
 #[derive(Debug)]
-pub struct HirFunctionCallableSymbol<'hir> {
+pub struct HirFunctionReferenceSymbol<'hir> {
     pub name: &'hir str,
     pub name_span: Span,
     /// The type arguments that the callable reference was instantiated with.
@@ -169,7 +166,7 @@ pub struct HirFunctionCallableSymbol<'hir> {
 }
 
 #[derive(Debug)]
-pub struct HirTraitFunctionCallableSymbol<'hir> {
+pub struct HirTraitMethodReferenceSymbol<'hir> {
     pub trait_name: &'hir str,
     pub trait_name_span: Span,
     pub trait_type_arguments: Vec<&'hir HirTy<'hir>>,
@@ -179,13 +176,13 @@ pub struct HirTraitFunctionCallableSymbol<'hir> {
     pub instantiated_call_parameters: Vec<&'hir HirTy<'hir>>,
 }
 
-impl<'hir> HirCallableSymbol<'hir> {
+impl<'hir> HirReferenceSymbol<'hir> {
     pub fn new_function(
         name: &'hir str,
         name_span: Span,
         type_arguments: Vec<&'hir HirTy<'hir>>,
     ) -> Self {
-        Self::Function(HirFunctionCallableSymbol {
+        Self::Function(HirFunctionReferenceSymbol {
             name,
             name_span,
             type_arguments,
@@ -201,7 +198,7 @@ impl<'hir> HirCallableSymbol<'hir> {
         method_name_span: Span,
         method_type_arguments: Vec<&'hir HirTy<'hir>>,
     ) -> Self {
-        Self::TraitFunction(HirTraitFunctionCallableSymbol {
+        Self::TraitMethod(HirTraitMethodReferenceSymbol {
             trait_name,
             trait_name_span,
             trait_type_arguments,

--- a/compiler/eight-middle/src/hir_builder.rs
+++ b/compiler/eight-middle/src/hir_builder.rs
@@ -15,7 +15,7 @@ use crate::hir::{
     HirInstance, HirInstanceSignature, HirIntegerLiteralExpr, HirLetStmt, HirLoopStmt,
     HirOffsetIndexExpr, HirReferenceExpr, HirReturnStmt, HirStmt, HirTrait, HirTraitSignature,
 };
-use crate::hir::{HirCallableReferenceExpr, HirCallableSymbol, HirTy};
+use crate::hir::{HirReferenceSymbol, HirTy};
 use crate::{HirResult, LinkageType};
 use eight_span::Span;
 use std::collections::BTreeMap;
@@ -318,20 +318,14 @@ impl<'hir> HirBuilder {
         name: &'hir str,
         name_span: Span,
         ty: &'hir HirTy<'hir>,
+        kind: HirReferenceSymbol<'hir>,
     ) -> HirReferenceExpr<'hir> {
         HirReferenceExpr {
             span,
             name,
             name_span,
             ty,
+            kind,
         }
-    }
-
-    pub fn build_callable_reference_expr(
-        span: Span,
-        symbol: HirCallableSymbol<'hir>,
-        ty: &'hir HirTy<'hir>,
-    ) -> HirCallableReferenceExpr<'hir> {
-        HirCallableReferenceExpr { span, symbol, ty }
     }
 }

--- a/compiler/eight-middle/src/hir_builder.rs
+++ b/compiler/eight-middle/src/hir_builder.rs
@@ -315,17 +315,9 @@ impl<'hir> HirBuilder {
 
     pub fn build_reference_expr(
         span: Span,
-        name: &'hir str,
-        name_span: Span,
         ty: &'hir HirTy<'hir>,
         kind: HirReferenceSymbol<'hir>,
     ) -> HirReferenceExpr<'hir> {
-        HirReferenceExpr {
-            span,
-            name,
-            name_span,
-            ty,
-            kind,
-        }
+        HirReferenceExpr { span, ty, kind }
     }
 }

--- a/compiler/eight-middle/src/hir_lowering_pass/mod.rs
+++ b/compiler/eight-middle/src/hir_lowering_pass/mod.rs
@@ -213,9 +213,9 @@ impl<'hir, 'mir> MirModuleLoweringPass<'mir> {
         expr: &'hir HirReferenceExpr<'hir>,
     ) -> MirResult<MirValueId> {
         match &expr.kind {
-            HirReferenceSymbol::Local => {
-                let id = self.locals.find(&expr.name).unwrap_or_else(|| {
-                    ice!("failed to find local value for {}", expr.name);
+            HirReferenceSymbol::Local(local) => {
+                let id = self.locals.find(&local.name).unwrap_or_else(|| {
+                    ice!("failed to find local value for {}", local.name);
                 });
                 let value_ty = b.data().get_value_type(*id);
                 let expected_ty = self.visit_ty(expr.ty)?;

--- a/compiler/eight-middle/src/hir_lowering_pass/mod.rs
+++ b/compiler/eight-middle/src/hir_lowering_pass/mod.rs
@@ -2,9 +2,9 @@ use crate::context::CompileContext;
 use crate::hir::{
     HirBooleanLiteralExpr, HirCallExpr, HirExpr, HirIntegerLiteralExpr, HirReferenceExpr,
 };
-use crate::hir::{HirCallableReferenceExpr, HirCallableSymbol, HirModule};
 use crate::hir::{HirExprStmt, HirFunction, HirLetStmt, HirStmt};
 use crate::hir::{HirGroupExpr, HirTy};
+use crate::hir::{HirModule, HirReferenceSymbol};
 use crate::mir::MirModule;
 use crate::mir::MirTy;
 use crate::mir::MirValueId;
@@ -167,7 +167,6 @@ impl<'hir, 'mir> MirModuleLoweringPass<'mir> {
         match expr {
             HirExpr::IntegerLiteral(e) => self.visit_integer_literal_expr(b, cx, e),
             HirExpr::Reference(e) => self.visit_reference_expr(b, cx, e),
-            HirExpr::CallableReference(e) => self.visit_callable_reference_expr(b, cx, e),
             HirExpr::Call(e) => self.visit_call_expr(b, cx, e),
             HirExpr::BooleanLiteral(e) => self.visit_boolean_literal_expr(b, cx, e),
             HirExpr::Group(e) => self.visit_group_expr(b, cx, e),
@@ -213,29 +212,21 @@ impl<'hir, 'mir> MirModuleLoweringPass<'mir> {
         cx: &MirModuleContext<'mir, 'hir>,
         expr: &'hir HirReferenceExpr<'hir>,
     ) -> MirResult<MirValueId> {
-        // Arguments can be used directly, but locals need to be loaded.
-        let id = self.locals.find(&expr.name).unwrap_or_else(|| {
-            ice!("failed to find local value for {}", expr.name);
-        });
-        let value_ty = b.data().get_value_type(*id);
-        let expected_ty = self.visit_ty(expr.ty)?;
-        // If it is a pointer type, we automatically dereference it.
-        if let MirTy::Pointer(_) = value_ty {
-            let load = b.build_load(cx, *id, expected_ty, None);
-            return Ok(load);
-        }
-        Ok(*id)
-    }
-
-    pub fn visit_callable_reference_expr(
-        &mut self,
-        b: &mut MirFunctionBuilder<'mir>,
-        cx: &MirModuleContext<'mir, 'hir>,
-        expr: &'hir HirCallableReferenceExpr<'hir>,
-    ) -> MirResult<MirValueId> {
-        match &expr.symbol {
-            // If this is a simple function name, we can lower it to a specific function value.
-            HirCallableSymbol::Function(symbol) => {
+        match &expr.kind {
+            HirReferenceSymbol::Local => {
+                let id = self.locals.find(&expr.name).unwrap_or_else(|| {
+                    ice!("failed to find local value for {}", expr.name);
+                });
+                let value_ty = b.data().get_value_type(*id);
+                let expected_ty = self.visit_ty(expr.ty)?;
+                // If it is a pointer type, we automatically dereference it.
+                if let MirTy::Pointer(_) = value_ty {
+                    let load = b.build_load(cx, *id, expected_ty, None);
+                    return Ok(load);
+                }
+                Ok(*id)
+            }
+            HirReferenceSymbol::Function(symbol) => {
                 // TODO: Mangle the name along with the type arguments.
                 let name = self.cc.intern_str(symbol.name);
                 let id = cx.data().get_function_id(name).unwrap_or_else(|| {
@@ -246,8 +237,8 @@ impl<'hir, 'mir> MirModuleLoweringPass<'mir> {
                 });
                 Ok(b.build_function_ref(id))
             }
-            HirCallableSymbol::TraitFunction(_) => unimplemented!(),
-            HirCallableSymbol::Intrinsic(_) => unimplemented!(),
+            HirReferenceSymbol::Intrinsic(_) => unimplemented!(),
+            HirReferenceSymbol::TraitMethod(_) => unimplemented!(),
         }
     }
 

--- a/compiler/eight-middle/src/hir_lowering_pass/mod.rs
+++ b/compiler/eight-middle/src/hir_lowering_pass/mod.rs
@@ -235,9 +235,9 @@ impl<'hir, 'mir> MirModuleLoweringPass<'mir> {
     ) -> MirResult<MirValueId> {
         match &expr.symbol {
             // If this is a simple function name, we can lower it to a specific function value.
-            HirCallableSymbol::Function(s) => {
+            HirCallableSymbol::Function(symbol) => {
                 // TODO: Mangle the name along with the type arguments.
-                let name = self.cc.intern_str(s.name);
+                let name = self.cc.intern_str(symbol.name);
                 let id = cx.data().get_function_id(name).unwrap_or_else(|| {
                     ice!(
                         "failed to find function id for {} despite passing type checker",
@@ -246,7 +246,8 @@ impl<'hir, 'mir> MirModuleLoweringPass<'mir> {
                 });
                 Ok(b.build_function_ref(id))
             }
-            _ => unimplemented!(),
+            HirCallableSymbol::TraitFunction(_) => unimplemented!(),
+            HirCallableSymbol::Intrinsic(_) => unimplemented!(),
         }
     }
 

--- a/compiler/eight-middle/src/hir_textual_pass/mod.rs
+++ b/compiler/eight-middle/src/hir_textual_pass/mod.rs
@@ -10,8 +10,7 @@
 use crate::hir::{
     HirAddressOfExpr, HirAssignExpr, HirBooleanLiteralExpr, HirCallExpr, HirCallableReferenceExpr,
     HirCallableSymbol, HirConstantIndexExpr, HirConstructExpr, HirConstructExprArgument,
-    HirDerefExpr, HirExpr, HirFunction, HirGroupExpr, HirInstance, HirIntegerLiteralExpr,
-    HirOffsetIndexExpr, HirReferenceExpr,
+    HirDerefExpr, HirExpr, HirFunction, HirGroupExpr, HirInstance, HirIntegerLiteralExpr, HirOffsetIndexExpr, HirReferenceExpr,
 };
 use crate::hir::{
     HirBlockStmt, HirBreakStmt, HirContinueStmt, HirExprStmt, HirFunctionParameterSignature,
@@ -660,6 +659,7 @@ impl<'a> HirModuleTextualPass<'a> {
                     self.arena.text(","),
                 ))
                 .append(self.arena.text(">")),
+            HirCallableSymbol::Intrinsic(intrinsic) => self.arena.text(intrinsic.to_string()),
         }
     }
 

--- a/compiler/eight-middle/src/hir_textual_pass/mod.rs
+++ b/compiler/eight-middle/src/hir_textual_pass/mod.rs
@@ -8,9 +8,9 @@
 //! invents syntax not found in the base language, such as statement blocks and while loops.
 
 use crate::hir::{
-    HirAddressOfExpr, HirAssignExpr, HirBooleanLiteralExpr, HirCallExpr, HirCallableReferenceExpr,
-    HirCallableSymbol, HirConstantIndexExpr, HirConstructExpr, HirConstructExprArgument,
-    HirDerefExpr, HirExpr, HirFunction, HirGroupExpr, HirInstance, HirIntegerLiteralExpr, HirOffsetIndexExpr, HirReferenceExpr,
+    HirAddressOfExpr, HirAssignExpr, HirBooleanLiteralExpr, HirCallExpr, HirConstantIndexExpr,
+    HirConstructExpr, HirConstructExprArgument, HirDerefExpr, HirExpr, HirFunction, HirGroupExpr,
+    HirInstance, HirIntegerLiteralExpr, HirOffsetIndexExpr, HirReferenceExpr, HirReferenceSymbol,
 };
 use crate::hir::{
     HirBlockStmt, HirBreakStmt, HirContinueStmt, HirExprStmt, HirFunctionParameterSignature,
@@ -577,7 +577,6 @@ impl<'a> HirModuleTextualPass<'a> {
             HirExpr::BooleanLiteral(e) => self.visit_boolean_literal_expr(e),
             HirExpr::Assign(e) => self.visit_assign_expr(e),
             HirExpr::Reference(e) => self.visit_reference_expr(e),
-            HirExpr::CallableReference(e) => self.visit_callable_reference_expr(e),
             HirExpr::ConstantIndex(e) => self.visit_constant_index_expr(e),
             HirExpr::OffsetIndex(e) => self.visit_offset_index_expr(e),
             HirExpr::Call(e) => self.visit_call_expr(e),
@@ -623,15 +622,9 @@ impl<'a> HirModuleTextualPass<'a> {
         &'a self,
         expr: &'hir HirReferenceExpr,
     ) -> DocBuilder<'a, Arena<'a>> {
-        self.arena.text(expr.name)
-    }
-
-    pub fn visit_callable_reference_expr<'hir: 'a>(
-        &'a self,
-        expr: &'hir HirCallableReferenceExpr,
-    ) -> DocBuilder<'a, Arena<'a>> {
-        match &expr.symbol {
-            HirCallableSymbol::Function(s) => self
+        match &expr.kind {
+            HirReferenceSymbol::Local => self.arena.text(expr.name),
+            HirReferenceSymbol::Function(s) => self
                 .arena
                 .text(s.name)
                 .append(self.arena.text("::"))
@@ -641,7 +634,7 @@ impl<'a> HirModuleTextualPass<'a> {
                     self.arena.text(","),
                 ))
                 .append(self.arena.text(">")),
-            HirCallableSymbol::TraitFunction(s) => self
+            HirReferenceSymbol::TraitMethod(s) => self
                 .arena
                 .text(s.trait_name)
                 .append(self.arena.text("<"))
@@ -659,7 +652,7 @@ impl<'a> HirModuleTextualPass<'a> {
                     self.arena.text(","),
                 ))
                 .append(self.arena.text(">")),
-            HirCallableSymbol::Intrinsic(intrinsic) => self.arena.text(intrinsic.to_string()),
+            HirReferenceSymbol::Intrinsic(intrinsic) => self.arena.text(intrinsic.to_string()),
         }
     }
 

--- a/compiler/eight-middle/src/hir_textual_pass/mod.rs
+++ b/compiler/eight-middle/src/hir_textual_pass/mod.rs
@@ -623,7 +623,7 @@ impl<'a> HirModuleTextualPass<'a> {
         expr: &'hir HirReferenceExpr,
     ) -> DocBuilder<'a, Arena<'a>> {
         match &expr.kind {
-            HirReferenceSymbol::Local => self.arena.text(expr.name),
+            HirReferenceSymbol::Local(s) => self.arena.text(s.name),
             HirReferenceSymbol::Function(s) => self
                 .arena
                 .text(s.name)

--- a/compiler/eight-middle/src/hir_type_check_pass/mod.rs
+++ b/compiler/eight-middle/src/hir_type_check_pass/mod.rs
@@ -1,16 +1,15 @@
 mod typing_context;
 
 use crate::hir::{
-    HirAddressOfExpr, HirAssignExpr, HirBooleanLiteralExpr, HirCallExpr, HirCallableReferenceExpr,
-    HirCallableSymbol, HirConstantIndexExpr, HirConstructExpr, HirDerefExpr, HirExpr, HirFunction,
-    HirGroupExpr, HirInstance, HirIntegerLiteralExpr, HirOffsetIndexExpr, HirReferenceExpr,
-    HirStruct, HirTrait,
+    HirAddressOfExpr, HirAssignExpr, HirBooleanLiteralExpr, HirCallExpr, HirConstantIndexExpr,
+    HirConstructExpr, HirDerefExpr, HirExpr, HirFunction, HirGroupExpr, HirInstance,
+    HirIntegerLiteralExpr, HirOffsetIndexExpr, HirReferenceExpr, HirReferenceSymbol, HirStruct,
+    HirTrait,
 };
 use crate::hir::{
     HirBlockStmt, HirExprStmt, HirFunctionTy, HirIfStmt, HirLetStmt, HirLoopStmt, HirModule,
     HirPointerTy, HirReturnStmt, HirStmt, HirTy,
 };
-use crate::hir_builder::HirBuilder;
 use crate::HirResult;
 use eight_diagnostics::errors::hir::{
     HirError, InvalidReferenceError, TypeFieldInfiniteRecursionError, UnknownTypeError,
@@ -95,21 +94,6 @@ pub struct DereferenceableConstraint<'hir> {
     /// The type that it should dereference into
     pub expectation: &'hir HirTy<'hir>,
     pub span: Span,
-}
-
-/// Replace the $expr node with the result of $app if it changed, optionally wrapped in the function
-/// $gen.
-macro_rules! substitute_if_changed {
-    ($expr:expr, $app:expr) => {
-        if let Some(next) = $app {
-            let _ = std::mem::replace($expr, next);
-        }
-    };
-    ($expr:expr, $app:expr, $gen:expr) => {
-        if let Some(next) = $app {
-            let _ = std::mem::replace($expr, $gen(next));
-        }
-    };
 }
 
 pub struct HirModuleTypeCheckerPass();
@@ -211,15 +195,11 @@ impl HirModuleTypeCheckerPass {
         // child nodes of the function body, then we solve the type constraints, and finally we
         // traverse once more to perform substitution of each node.
         for stmt in node.body.iter_mut() {
-            if let Some(next) = Self::enter_stmt(cx, stmt)? {
-                let _ = std::mem::replace(stmt, next);
-            }
+            Self::enter_stmt(cx, stmt)?;
         }
         cx.solve_constraints()?;
         for stmt in node.body.iter_mut() {
-            if let Some(next) = Self::leave_stmt(cx, stmt)? {
-                let _ = std::mem::replace(stmt, next);
-            }
+            Self::leave_stmt(cx, stmt)?;
         }
         cx.leave_let_binding_scope();
         cx.record_function_context_exit();
@@ -457,13 +437,12 @@ impl HirModuleTypeCheckerPass {
     pub fn enter_expr<'hir>(
         cx: &mut TypingContext<'hir>,
         node: &mut HirExpr<'hir>,
-    ) -> HirResult<Option<HirExpr<'hir>>> {
+    ) -> HirResult<()> {
         match node {
             HirExpr::IntegerLiteral(e) => Self::enter_integer_literal_expr(cx, e),
             HirExpr::BooleanLiteral(e) => Self::enter_boolean_literal_expr(cx, e),
             HirExpr::Group(e) => Self::enter_group_expr(cx, e),
             HirExpr::Reference(e) => Self::enter_reference_expr(cx, e),
-            HirExpr::CallableReference(e) => Self::enter_callable_reference_expr(cx, e),
             HirExpr::Assign(e) => Self::enter_assign_expr(cx, e),
             HirExpr::OffsetIndex(e) => Self::enter_offset_index_expr(cx, e),
             HirExpr::ConstantIndex(e) => Self::enter_constant_index_expr(cx, e),
@@ -478,13 +457,12 @@ impl HirModuleTypeCheckerPass {
     pub fn leave_expr<'hir>(
         cx: &mut TypingContext<'hir>,
         node: &mut HirExpr<'hir>,
-    ) -> HirResult<Option<HirExpr<'hir>>> {
+    ) -> HirResult<()> {
         match node {
             HirExpr::IntegerLiteral(e) => Self::leave_integer_literal_expr(cx, e),
             HirExpr::BooleanLiteral(e) => Self::leave_boolean_literal_expr(cx, e),
             HirExpr::Group(e) => Self::leave_group_expr(cx, e),
             HirExpr::Reference(e) => Self::leave_reference_expr(cx, e),
-            HirExpr::CallableReference(e) => Self::leave_callable_reference_expr(cx, e),
             HirExpr::Assign(e) => Self::leave_assign_expr(cx, e),
             HirExpr::OffsetIndex(e) => Self::leave_offset_index_expr(cx, e),
             HirExpr::ConstantIndex(e) => Self::leave_constant_index_expr(cx, e),
@@ -501,19 +479,19 @@ impl HirModuleTypeCheckerPass {
     pub fn enter_integer_literal_expr<'hir>(
         cx: &mut TypingContext<'hir>,
         node: &mut HirIntegerLiteralExpr<'hir>,
-    ) -> HirResult<Option<HirExpr<'hir>>> {
+    ) -> HirResult<()> {
         node.ty = Self::visit_type(cx, node.ty)?;
         cx.infer_integer_literal_expr(node, node.ty)?;
-        Ok(None)
+        Ok(())
     }
 
     /// Perform substitution for an integer literal expression.
     pub fn leave_integer_literal_expr<'hir>(
         cx: &mut TypingContext<'hir>,
         node: &mut HirIntegerLiteralExpr<'hir>,
-    ) -> HirResult<Option<HirExpr<'hir>>> {
+    ) -> HirResult<()> {
         node.ty = cx.substitute(node.ty)?;
-        Ok(None)
+        Ok(())
     }
 
     /// Collect type constraints for a boolean literal expression.
@@ -522,19 +500,19 @@ impl HirModuleTypeCheckerPass {
     pub fn enter_boolean_literal_expr<'hir>(
         cx: &mut TypingContext<'hir>,
         node: &mut HirBooleanLiteralExpr<'hir>,
-    ) -> HirResult<Option<HirExpr<'hir>>> {
+    ) -> HirResult<()> {
         node.ty = Self::visit_type(cx, node.ty)?;
         cx.infer_boolean_literal_expr(node, node.ty)?;
-        Ok(None)
+        Ok(())
     }
 
     /// Perform substitution for a boolean literal expression.
     pub fn leave_boolean_literal_expr<'hir>(
         cx: &mut TypingContext<'hir>,
         node: &mut HirBooleanLiteralExpr<'hir>,
-    ) -> HirResult<Option<HirExpr<'hir>>> {
+    ) -> HirResult<()> {
         node.ty = cx.substitute(node.ty)?;
-        Ok(None)
+        Ok(())
     }
 
     /// Collect type constraints for a group expression.
@@ -543,29 +521,21 @@ impl HirModuleTypeCheckerPass {
     pub fn enter_group_expr<'hir>(
         cx: &mut TypingContext<'hir>,
         node: &mut HirGroupExpr<'hir>,
-    ) -> HirResult<Option<HirExpr<'hir>>> {
+    ) -> HirResult<()> {
         node.ty = Self::visit_type(cx, node.ty)?;
-        substitute_if_changed!(
-            &mut node.inner,
-            Self::enter_expr(cx, &mut node.inner)?,
-            Box::new
-        );
+        Self::enter_expr(cx, &mut node.inner)?;
         cx.infer_group_expr(node, node.ty)?;
-        Ok(None)
+        Ok(())
     }
 
     /// Perform substitution for a group expression.
     pub fn leave_group_expr<'hir>(
         cx: &mut TypingContext<'hir>,
         node: &mut HirGroupExpr<'hir>,
-    ) -> HirResult<Option<HirExpr<'hir>>> {
-        substitute_if_changed!(
-            &mut node.inner,
-            Self::leave_expr(cx, &mut node.inner)?,
-            Box::new
-        );
+    ) -> HirResult<()> {
+        Self::leave_expr(cx, &mut node.inner)?;
         node.ty = cx.substitute(node.ty)?;
-        Ok(None)
+        Ok(())
     }
 
     /// Collect type constraints for a reference expression.
@@ -577,7 +547,7 @@ impl HirModuleTypeCheckerPass {
     pub fn enter_reference_expr<'hir>(
         cx: &mut TypingContext<'hir>,
         node: &mut HirReferenceExpr<'hir>,
-    ) -> HirResult<Option<HirExpr<'hir>>> {
+    ) -> HirResult<()> {
         node.ty = Self::visit_type(cx, node.ty)?;
         // See if the name resolves to a local let-binding or a function name.
         let is_local_reference = cx.find_let_binding(node.name).is_some();
@@ -587,18 +557,9 @@ impl HirModuleTypeCheckerPass {
         // may shadow a function), we can add metadata to the expression.
         let is_definitely_function = is_function_reference && !is_local_reference;
         if is_definitely_function {
-            let mut node = HirBuilder::build_callable_reference_expr(
-                node.span,
-                // TODO: This vec![] should be filled if we ever support stuff like
-                // let k = id::<i32>
-                HirCallableSymbol::new_function(node.name, node.name_span, vec![]),
-                node.ty,
-            );
-            let ty = node.ty;
-            cx.infer_callable_reference_expr(&mut node, ty)?;
-            return Ok(Some(HirExpr::CallableReference(node)));
+            // TODO: This vec![] should be filled if we ever support stuff like let k = id::<i32>
+            node.kind = HirReferenceSymbol::new_function(node.name, node.name_span, vec![]);
         }
-
         // If we don't know where this name comes from, we have a type error.
         if !is_local_reference && !is_function_reference {
             return Err(HirError::InvalidReference(InvalidReferenceError {
@@ -607,61 +568,29 @@ impl HirModuleTypeCheckerPass {
             }));
         }
         cx.infer_reference_expr(node, node.ty)?;
-        Ok(None)
+        Ok(())
     }
 
     /// Perform substitution for a reference expression.
     pub fn leave_reference_expr<'hir>(
         cx: &mut TypingContext<'hir>,
         node: &mut HirReferenceExpr<'hir>,
-    ) -> HirResult<Option<HirExpr<'hir>>> {
+    ) -> HirResult<()> {
         node.ty = cx.substitute(node.ty)?;
-        Ok(None)
+        Ok(())
     }
 
-    /// Collect type constraints for a callable reference expression.
-    ///
-    /// This doesn't actually do anything, because we rewrite function calls and references to these
-    /// after the types have been inferred.
-    pub fn enter_callable_reference_expr<'hir>(
+    pub fn enter_reference_symbol<'hir>(
         cx: &mut TypingContext<'hir>,
-        node: &mut HirCallableReferenceExpr<'hir>,
-    ) -> HirResult<Option<HirExpr<'hir>>> {
-        node.ty = Self::visit_type(cx, node.ty)?;
-        substitute_if_changed!(
-            &mut node.symbol,
-            Self::enter_callable_symbol(cx, &mut node.symbol)?
-        );
-        cx.infer_callable_reference_expr(node, node.ty)?;
-        Ok(None)
-    }
-
-    /// Perform substitution for a callable reference expression.
-    ///
-    /// Same explanation as `enter_callable_reference_expr`.
-    pub fn leave_callable_reference_expr<'hir>(
-        cx: &mut TypingContext<'hir>,
-        node: &mut HirCallableReferenceExpr<'hir>,
-    ) -> HirResult<Option<HirExpr<'hir>>> {
-        node.ty = cx.substitute(node.ty)?;
-        substitute_if_changed!(
-            &mut node.symbol,
-            Self::leave_callable_symbol(cx, &mut node.symbol)?
-        );
-        Ok(None)
-    }
-
-    pub fn enter_callable_symbol<'hir>(
-        cx: &mut TypingContext<'hir>,
-        node: &mut HirCallableSymbol<'hir>,
-    ) -> HirResult<Option<HirCallableSymbol<'hir>>> {
+        node: &mut HirReferenceSymbol<'hir>,
+    ) -> HirResult<()> {
         match node {
-            HirCallableSymbol::Function(sym) => {
+            HirReferenceSymbol::Function(sym) => {
                 for argument in sym.type_arguments.iter_mut() {
                     *argument = Self::visit_type(cx, argument)?;
                 }
             }
-            HirCallableSymbol::TraitFunction(sym) => {
+            HirReferenceSymbol::TraitMethod(sym) => {
                 for argument in sym.trait_type_arguments.iter_mut() {
                     *argument = Self::visit_type(cx, argument)?;
                 }
@@ -669,24 +598,25 @@ impl HirModuleTypeCheckerPass {
                     *argument = Self::visit_type(cx, argument)?;
                 }
             }
+            HirReferenceSymbol::Local => {}
             // These are constructed post-unification, so there is no way for these to be
             // constructed before.
-            HirCallableSymbol::Intrinsic(_) => ice!("cannot visit intrinsic callable symbol"),
+            HirReferenceSymbol::Intrinsic(_) => ice!("cannot visit intrinsic callable symbol"),
         }
-        Ok(None)
+        Ok(())
     }
 
-    pub fn leave_callable_symbol<'hir>(
+    pub fn leave_reference_symbol<'hir>(
         cx: &mut TypingContext<'hir>,
-        node: &mut HirCallableSymbol<'hir>,
-    ) -> HirResult<Option<HirCallableSymbol<'hir>>> {
+        node: &mut HirReferenceSymbol<'hir>,
+    ) -> HirResult<()> {
         match node {
-            HirCallableSymbol::Function(sym) => {
+            HirReferenceSymbol::Function(sym) => {
                 for argument in sym.type_arguments.iter_mut() {
                     *argument = cx.substitute(argument)?;
                 }
             }
-            HirCallableSymbol::TraitFunction(sym) => {
+            HirReferenceSymbol::TraitMethod(sym) => {
                 for argument in sym.trait_type_arguments.iter_mut() {
                     *argument = cx.substitute(argument)?;
                 }
@@ -694,9 +624,9 @@ impl HirModuleTypeCheckerPass {
                     *argument = cx.substitute(argument)?;
                 }
             }
-            HirCallableSymbol::Intrinsic(_) => {}
+            HirReferenceSymbol::Local | HirReferenceSymbol::Intrinsic(_) => {}
         }
-        Ok(None)
+        Ok(())
     }
 
     /// Collect type constraints for an assign expression.
@@ -706,39 +636,23 @@ impl HirModuleTypeCheckerPass {
     pub fn enter_assign_expr<'hir>(
         cx: &mut TypingContext<'hir>,
         node: &mut HirAssignExpr<'hir>,
-    ) -> HirResult<Option<HirExpr<'hir>>> {
+    ) -> HirResult<()> {
         node.ty = Self::visit_type(cx, node.ty)?;
-        substitute_if_changed!(
-            &mut node.lhs,
-            Self::enter_expr(cx, &mut node.lhs)?,
-            Box::new
-        );
-        substitute_if_changed!(
-            &mut node.rhs,
-            Self::enter_expr(cx, &mut node.rhs)?,
-            Box::new
-        );
+        Self::enter_expr(cx, &mut node.lhs)?;
+        Self::enter_expr(cx, &mut node.rhs)?;
         cx.infer_assign_expr(node, node.ty)?;
-        Ok(None)
+        Ok(())
     }
 
     /// Perform substitution for an assignment expression.
     pub fn leave_assign_expr<'hir>(
         cx: &mut TypingContext<'hir>,
         node: &mut HirAssignExpr<'hir>,
-    ) -> HirResult<Option<HirExpr<'hir>>> {
-        substitute_if_changed!(
-            &mut node.lhs,
-            Self::leave_expr(cx, &mut node.lhs)?,
-            Box::new
-        );
-        substitute_if_changed!(
-            &mut node.rhs,
-            Self::leave_expr(cx, &mut node.rhs)?,
-            Box::new
-        );
+    ) -> HirResult<()> {
+        Self::leave_expr(cx, &mut node.lhs)?;
+        Self::leave_expr(cx, &mut node.rhs)?;
         node.ty = cx.substitute(node.ty)?;
-        Ok(None)
+        Ok(())
     }
 
     /// Collect type constraints for an offset index expression.
@@ -748,83 +662,55 @@ impl HirModuleTypeCheckerPass {
     pub fn enter_offset_index_expr<'hir>(
         cx: &mut TypingContext<'hir>,
         node: &mut HirOffsetIndexExpr<'hir>,
-    ) -> HirResult<Option<HirExpr<'hir>>> {
+    ) -> HirResult<()> {
         node.ty = Self::visit_type(cx, node.ty)?;
-        substitute_if_changed!(
-            &mut node.origin,
-            Self::enter_expr(cx, &mut node.origin)?,
-            Box::new
-        );
-        substitute_if_changed!(
-            &mut node.index,
-            Self::enter_expr(cx, &mut node.index)?,
-            Box::new
-        );
+        Self::enter_expr(cx, &mut node.origin)?;
+        Self::enter_expr(cx, &mut node.index)?;
         cx.infer_offset_index_expr(node, node.ty)?;
-        Ok(None)
+        Ok(())
     }
 
     /// Perform substitution for an offset index expression.
     pub fn leave_offset_index_expr<'hir>(
         cx: &mut TypingContext<'hir>,
         node: &mut HirOffsetIndexExpr<'hir>,
-    ) -> HirResult<Option<HirExpr<'hir>>> {
-        substitute_if_changed!(
-            &mut node.origin,
-            Self::leave_expr(cx, &mut node.origin)?,
-            Box::new
-        );
-        substitute_if_changed!(
-            &mut node.index,
-            Self::leave_expr(cx, &mut node.index)?,
-            Box::new
-        );
+    ) -> HirResult<()> {
+        Self::leave_expr(cx, &mut node.origin)?;
+        Self::leave_expr(cx, &mut node.index)?;
         node.ty = cx.substitute(node.ty)?;
-        Ok(None)
+        Ok(())
     }
 
     /// Collect type constraints for a constant index expression.
     pub fn enter_constant_index_expr<'hir>(
         cx: &mut TypingContext<'hir>,
         node: &mut HirConstantIndexExpr<'hir>,
-    ) -> HirResult<Option<HirExpr<'hir>>> {
+    ) -> HirResult<()> {
         node.ty = Self::visit_type(cx, node.ty)?;
-        substitute_if_changed!(
-            &mut node.origin,
-            Self::enter_expr(cx, &mut node.origin)?,
-            Box::new
-        );
+        Self::enter_expr(cx, &mut node.origin)?;
         cx.infer_constant_index_expr(node, node.ty)?;
-        Ok(None)
+        Ok(())
     }
 
     /// Perform substitution for a constant index expression.
     pub fn leave_constant_index_expr<'hir>(
         cx: &mut TypingContext<'hir>,
         node: &mut HirConstantIndexExpr<'hir>,
-    ) -> HirResult<Option<HirExpr<'hir>>> {
-        substitute_if_changed!(
-            &mut node.origin,
-            Self::leave_expr(cx, &mut node.origin)?,
-            Box::new
-        );
+    ) -> HirResult<()> {
+        Self::leave_expr(cx, &mut node.origin)?;
         node.ty = cx.substitute(node.ty)?;
-        Ok(None)
+        Ok(())
     }
 
     /// Collect type constraints for a call expression.
     pub fn enter_call_expr<'hir>(
         cx: &mut TypingContext<'hir>,
         node: &mut HirCallExpr<'hir>,
-    ) -> HirResult<Option<HirExpr<'hir>>> {
+    ) -> HirResult<()> {
         node.ty = Self::visit_type(cx, node.ty)?;
-        substitute_if_changed!(
-            &mut node.callee,
-            Self::enter_expr(cx, &mut node.callee)?,
-            Box::new
-        );
+        Self::enter_expr(cx, &mut node.callee)?;
         for argument in node.arguments.iter_mut() {
-            substitute_if_changed!(argument, Self::enter_expr(cx, argument)?);
+            Self::enter_expr(cx, argument)?;
         }
         for arg in node.trait_type_arguments.iter_mut() {
             *arg = Self::visit_type(cx, arg)?;
@@ -833,24 +719,20 @@ impl HirModuleTypeCheckerPass {
             *arg = Self::visit_type(cx, arg)?;
         }
         for arg in node.arguments.iter_mut() {
-            substitute_if_changed!(arg, Self::enter_expr(cx, arg)?);
+            Self::enter_expr(cx, arg)?;
         }
         cx.infer_call_expr(node, node.ty)?;
-        Ok(None)
+        Ok(())
     }
 
     /// Perform substitution for a call expression.
     pub fn leave_call_expr<'hir>(
         cx: &mut TypingContext<'hir>,
         node: &mut HirCallExpr<'hir>,
-    ) -> HirResult<Option<HirExpr<'hir>>> {
-        substitute_if_changed!(
-            &mut node.callee,
-            Self::leave_expr(cx, &mut node.callee)?,
-            Box::new
-        );
+    ) -> HirResult<()> {
+        Self::leave_expr(cx, &mut node.callee)?;
         for argument in node.arguments.iter_mut() {
-            substitute_if_changed!(argument, Self::leave_expr(cx, argument)?);
+            Self::leave_expr(cx, argument)?;
         }
         for arg in node.trait_type_arguments.iter_mut() {
             *arg = cx.substitute(arg)?;
@@ -859,104 +741,80 @@ impl HirModuleTypeCheckerPass {
             *arg = cx.substitute(arg)?;
         }
         for arg in node.arguments.iter_mut() {
-            substitute_if_changed!(arg, Self::leave_expr(cx, arg)?);
+            Self::leave_expr(cx, arg)?;
         }
         node.ty = cx.substitute(node.ty)?;
-        Ok(None)
+        Ok(())
     }
 
     /// Collect type constraints for a construct expression.
     pub fn enter_construct_expr<'hir>(
         cx: &mut TypingContext<'hir>,
         node: &mut HirConstructExpr<'hir>,
-    ) -> HirResult<Option<HirExpr<'hir>>> {
+    ) -> HirResult<()> {
         // Nothing to re-assign here. This is just a check that the type that is being constructed
         // actually exists.
         Self::visit_type(cx, node.callee)?;
         node.ty = Self::visit_type(cx, node.ty)?;
         for arg in node.arguments.iter_mut() {
-            substitute_if_changed!(
-                &mut arg.expr,
-                Self::enter_expr(cx, arg.expr.as_mut())?,
-                Box::new
-            );
+            Self::enter_expr(cx, arg.expr.as_mut())?;
         }
         cx.infer_construct_expr(node, node.ty)?;
-        Ok(None)
+        Ok(())
     }
 
     /// Perform substitution for a construct expression.
     pub fn leave_construct_expr<'hir>(
         cx: &mut TypingContext<'hir>,
         node: &mut HirConstructExpr<'hir>,
-    ) -> HirResult<Option<HirExpr<'hir>>> {
+    ) -> HirResult<()> {
         node.ty = cx.substitute(node.ty)?;
         for arg in node.arguments.iter_mut() {
-            substitute_if_changed!(
-                &mut arg.expr,
-                Self::leave_expr(cx, &mut arg.expr)?,
-                Box::new
-            );
+            Self::leave_expr(cx, &mut arg.expr)?;
         }
-        Ok(None)
+        Ok(())
     }
 
     /// Collect type constraints for an address of expression.
     pub fn enter_address_of_expr<'hir>(
         cx: &mut TypingContext<'hir>,
         node: &mut HirAddressOfExpr<'hir>,
-    ) -> HirResult<Option<HirExpr<'hir>>> {
+    ) -> HirResult<()> {
         node.ty = Self::visit_type(cx, node.ty)?;
-        substitute_if_changed!(
-            &mut node.inner,
-            Self::enter_expr(cx, &mut node.inner)?,
-            Box::new
-        );
+        Self::enter_expr(cx, &mut node.inner)?;
         cx.infer_address_of_expr(node, node.ty)?;
-        Ok(None)
+        Ok(())
     }
 
     /// Perform substitution for an address of expression.
     pub fn leave_address_of_expr<'hir>(
         cx: &mut TypingContext<'hir>,
         node: &mut HirAddressOfExpr<'hir>,
-    ) -> HirResult<Option<HirExpr<'hir>>> {
-        substitute_if_changed!(
-            &mut node.inner,
-            Self::leave_expr(cx, &mut node.inner)?,
-            Box::new
-        );
+    ) -> HirResult<()> {
+        Self::leave_expr(cx, &mut node.inner)?;
         node.ty = cx.substitute(node.ty)?;
-        Ok(None)
+        Ok(())
     }
 
     /// Collect type constraints for a deref expression.
     pub fn enter_deref_expr<'hir>(
         cx: &mut TypingContext<'hir>,
         node: &mut HirDerefExpr<'hir>,
-    ) -> HirResult<Option<HirExpr<'hir>>> {
+    ) -> HirResult<()> {
         node.ty = Self::visit_type(cx, node.ty)?;
-        substitute_if_changed!(
-            &mut node.inner,
-            Self::enter_expr(cx, &mut node.inner)?,
-            Box::new
-        );
+        Self::enter_expr(cx, &mut node.inner)?;
         cx.infer_deref_expr(node, node.ty)?;
-        Ok(None)
+        Ok(())
     }
 
     /// Perform substitution for a deref expression.
     pub fn leave_deref_expr<'hir>(
         cx: &mut TypingContext<'hir>,
         node: &mut HirDerefExpr<'hir>,
-    ) -> HirResult<Option<HirExpr<'hir>>> {
-        substitute_if_changed!(
-            &mut node.inner,
-            Self::leave_expr(cx, &mut node.inner)?,
-            Box::new
-        );
+    ) -> HirResult<()> {
+        Self::leave_expr(cx, &mut node.inner)?;
         node.ty = cx.substitute(node.ty)?;
-        Ok(None)
+        Ok(())
     }
 
     /// Collect type constraints for a statement.
@@ -969,7 +827,7 @@ impl HirModuleTypeCheckerPass {
     pub fn enter_stmt<'hir>(
         cx: &mut TypingContext<'hir>,
         node: &mut HirStmt<'hir>,
-    ) -> HirResult<Option<HirStmt<'hir>>> {
+    ) -> HirResult<()> {
         match node {
             HirStmt::Let(s) => Self::enter_let_stmt(cx, s),
             HirStmt::Expr(e) => Self::enter_expr_stmt(cx, e),
@@ -978,7 +836,7 @@ impl HirModuleTypeCheckerPass {
             HirStmt::If(i) => Self::enter_if_stmt(cx, i),
             HirStmt::Block(b) => Self::enter_block_stmt(cx, b),
             // Nothing to do for these nodes.
-            HirStmt::Break(_) | HirStmt::Continue(_) => Ok(None),
+            HirStmt::Break(_) | HirStmt::Continue(_) => Ok(()),
         }
     }
 
@@ -986,7 +844,7 @@ impl HirModuleTypeCheckerPass {
     pub fn leave_stmt<'hir>(
         cx: &mut TypingContext<'hir>,
         node: &mut HirStmt<'hir>,
-    ) -> HirResult<Option<HirStmt<'hir>>> {
+    ) -> HirResult<()> {
         match node {
             HirStmt::Let(s) => Self::leave_let_stmt(cx, s),
             HirStmt::Expr(e) => Self::leave_expr_stmt(cx, e),
@@ -995,7 +853,7 @@ impl HirModuleTypeCheckerPass {
             HirStmt::If(i) => Self::leave_if_stmt(cx, i),
             HirStmt::Block(b) => Self::leave_block_stmt(cx, b),
             // Nothing to do for these nodes.
-            HirStmt::Break(_) | HirStmt::Continue(_) => Ok(None),
+            HirStmt::Break(_) | HirStmt::Continue(_) => Ok(()),
         }
     }
 
@@ -1006,101 +864,101 @@ impl HirModuleTypeCheckerPass {
     pub fn enter_let_stmt<'hir>(
         cx: &mut TypingContext<'hir>,
         node: &mut HirLetStmt<'hir>,
-    ) -> HirResult<Option<HirStmt<'hir>>> {
+    ) -> HirResult<()> {
         // Replace any uninitialized types with a fresh type variable.
         node.ty = Self::visit_type(cx, node.ty)?;
-        substitute_if_changed!(&mut node.value, Self::enter_expr(cx, &mut node.value)?);
+        Self::enter_expr(cx, &mut node.value)?;
         cx.infer(&mut node.value, node.ty)?;
         // Propagate the type of the expression to the type of the let-binding
         node.ty = node.value.ty();
         cx.record_let_binding(node.name, node.span, node.ty)?;
-        Ok(None)
+        Ok(())
     }
 
     /// Perform substitution for a let statement.
     pub fn leave_let_stmt<'hir>(
         cx: &mut TypingContext<'hir>,
         node: &mut HirLetStmt<'hir>,
-    ) -> HirResult<Option<HirStmt<'hir>>> {
-        substitute_if_changed!(&mut node.value, Self::leave_expr(cx, &mut node.value)?);
+    ) -> HirResult<()> {
+        Self::leave_expr(cx, &mut node.value)?;
         // Propagate the type of the expression to the type of the let-binding
         node.ty = node.value.ty();
-        Ok(None)
+        Ok(())
     }
 
     /// Collect type constraints for an expression statement.
     pub fn enter_expr_stmt<'hir>(
         cx: &mut TypingContext<'hir>,
         node: &mut HirExprStmt<'hir>,
-    ) -> HirResult<Option<HirStmt<'hir>>> {
-        substitute_if_changed!(&mut node.expr, Self::enter_expr(cx, &mut node.expr)?);
-        Ok(None)
+    ) -> HirResult<()> {
+        Self::enter_expr(cx, &mut node.expr)?;
+        Ok(())
     }
 
     /// Perform substitution for an expression statement.
     pub fn leave_expr_stmt<'hir>(
         cx: &mut TypingContext<'hir>,
         node: &mut HirExprStmt<'hir>,
-    ) -> HirResult<Option<HirStmt<'hir>>> {
-        substitute_if_changed!(&mut node.expr, Self::leave_expr(cx, &mut node.expr)?);
-        Ok(None)
+    ) -> HirResult<()> {
+        Self::leave_expr(cx, &mut node.expr)?;
+        Ok(())
     }
 
     /// Collect type constraints for a loop statement.
     pub fn enter_loop_stmt<'hir>(
         cx: &mut TypingContext<'hir>,
         node: &mut HirLoopStmt<'hir>,
-    ) -> HirResult<Option<HirStmt<'hir>>> {
+    ) -> HirResult<()> {
         cx.enter_let_binding_scope();
         for stmt in node.body.iter_mut() {
-            substitute_if_changed!(stmt, Self::enter_stmt(cx, stmt)?);
+            Self::enter_stmt(cx, stmt)?;
         }
         cx.leave_let_binding_scope();
-        Ok(None)
+        Ok(())
     }
 
     /// Perform substitution for a loop statement.
     pub fn leave_loop_stmt<'hir>(
         cx: &mut TypingContext<'hir>,
         node: &mut HirLoopStmt<'hir>,
-    ) -> HirResult<Option<HirStmt<'hir>>> {
+    ) -> HirResult<()> {
         for stmt in node.body.iter_mut() {
-            substitute_if_changed!(stmt, Self::leave_stmt(cx, stmt)?);
+            Self::leave_stmt(cx, stmt)?;
         }
-        Ok(None)
+        Ok(())
     }
 
     /// Collect type constraints for a block statement.
     pub fn enter_block_stmt<'hir>(
         cx: &mut TypingContext<'hir>,
         node: &mut HirBlockStmt<'hir>,
-    ) -> HirResult<Option<HirStmt<'hir>>> {
+    ) -> HirResult<()> {
         cx.enter_let_binding_scope();
         for stmt in node.body.iter_mut() {
-            substitute_if_changed!(stmt, Self::enter_stmt(cx, stmt)?);
+            Self::enter_stmt(cx, stmt)?;
         }
         cx.leave_let_binding_scope();
-        Ok(None)
+        Ok(())
     }
 
     /// Perform substitution for a block statement.
     pub fn leave_block_stmt<'hir>(
         cx: &mut TypingContext<'hir>,
         node: &mut HirBlockStmt<'hir>,
-    ) -> HirResult<Option<HirStmt<'hir>>> {
+    ) -> HirResult<()> {
         for stmt in node.body.iter_mut() {
-            substitute_if_changed!(stmt, Self::leave_stmt(cx, stmt)?);
+            Self::leave_stmt(cx, stmt)?;
         }
-        Ok(None)
+        Ok(())
     }
 
     /// Collect type constraints for a break statement.
     pub fn enter_return_stmt<'hir>(
         cx: &mut TypingContext<'hir>,
         node: &mut HirReturnStmt<'hir>,
-    ) -> HirResult<Option<HirStmt<'hir>>> {
+    ) -> HirResult<()> {
         if let Some(inner) = node.value.as_mut() {
-            substitute_if_changed!(inner, Self::enter_expr(cx, inner)?);
+            Self::enter_expr(cx, inner)?;
             let parent = cx
                 .find_function_context()
                 // In the future syntax like this might be legal, but even then it should be caught in
@@ -1108,64 +966,56 @@ impl HirModuleTypeCheckerPass {
                 .unwrap_or_else(|| ice!("tried to infer return statement outside of function"));
             cx.infer(inner, parent.return_type)?;
         }
-        Ok(None)
+        Ok(())
     }
 
     /// Perform substitution for a return statement.
     pub fn leave_return_stmt<'hir>(
         cx: &mut TypingContext<'hir>,
         node: &mut HirReturnStmt<'hir>,
-    ) -> HirResult<Option<HirStmt<'hir>>> {
+    ) -> HirResult<()> {
         if let Some(inner) = node.value.as_mut() {
-            substitute_if_changed!(inner, Self::leave_expr(cx, inner)?);
+            Self::leave_expr(cx, inner)?;
         }
-        Ok(None)
+        Ok(())
     }
 
     /// Collect type constraints for an if statement.
     pub fn enter_if_stmt<'hir>(
         cx: &mut TypingContext<'hir>,
         node: &mut HirIfStmt<'hir>,
-    ) -> HirResult<Option<HirStmt<'hir>>> {
-        substitute_if_changed!(
-            &mut node.condition,
-            Self::enter_expr(cx, &mut node.condition)?
-        );
+    ) -> HirResult<()> {
+        Self::enter_expr(cx, &mut node.condition)?;
         // We also impose a new constraint that the condition must be a boolean
         cx.infer(&mut node.condition, cx.cc.hir_boolean_type())?;
-
         // Traverse down the happy path
         cx.enter_let_binding_scope();
         for stmt in node.happy_path.iter_mut() {
-            substitute_if_changed!(stmt, Self::enter_stmt(cx, stmt)?);
+            Self::enter_stmt(cx, stmt)?;
         }
         cx.leave_let_binding_scope();
 
         // Traverse down the unhappy path
         cx.enter_let_binding_scope();
         for stmt in node.unhappy_path.iter_mut() {
-            substitute_if_changed!(stmt, Self::enter_stmt(cx, stmt)?);
+            Self::enter_stmt(cx, stmt)?;
         }
         cx.leave_let_binding_scope();
-        Ok(None)
+        Ok(())
     }
 
     pub fn leave_if_stmt<'hir>(
         cx: &mut TypingContext<'hir>,
         node: &mut HirIfStmt<'hir>,
-    ) -> HirResult<Option<HirStmt<'hir>>> {
-        substitute_if_changed!(
-            &mut node.condition,
-            Self::leave_expr(cx, &mut node.condition)?
-        );
+    ) -> HirResult<()> {
         Self::leave_expr(cx, &mut node.condition)?;
         for stmt in node.happy_path.iter_mut() {
-            substitute_if_changed!(stmt, Self::leave_stmt(cx, stmt)?);
+            Self::leave_stmt(cx, stmt)?;
         }
         for stmt in node.unhappy_path.iter_mut() {
-            substitute_if_changed!(stmt, Self::leave_stmt(cx, stmt)?);
+            Self::leave_stmt(cx, stmt)?;
         }
-        Ok(None)
+        Ok(())
     }
 }
 

--- a/compiler/eight-middle/src/hir_type_check_pass/mod.rs
+++ b/compiler/eight-middle/src/hir_type_check_pass/mod.rs
@@ -669,6 +669,9 @@ impl HirModuleTypeCheckerPass {
                     *argument = Self::visit_type(cx, argument)?;
                 }
             }
+            // These are constructed post-unification, so there is no way for these to be
+            // constructed before.
+            HirCallableSymbol::Intrinsic(_) => ice!("cannot visit intrinsic callable symbol"),
         }
         Ok(None)
     }
@@ -691,6 +694,7 @@ impl HirModuleTypeCheckerPass {
                     *argument = cx.substitute(argument)?;
                 }
             }
+            HirCallableSymbol::Intrinsic(_) => {}
         }
         Ok(None)
     }

--- a/compiler/eight-middle/src/hir_type_check_pass/mod.rs
+++ b/compiler/eight-middle/src/hir_type_check_pass/mod.rs
@@ -549,24 +549,46 @@ impl HirModuleTypeCheckerPass {
         node: &mut HirReferenceExpr<'hir>,
     ) -> HirResult<()> {
         node.ty = Self::visit_type(cx, node.ty)?;
-        // See if the name resolves to a local let-binding or a function name.
-        let is_local_reference = cx.find_let_binding(node.name).is_some();
-        let is_function_reference = cx.signature.query_function_by_name(node.name).is_some();
+        // When nodes arrive from AST lowering, local kinds are assumed to be unknown unless proven
+        // otherwise. This means that if we come across a local reference, we might have to change
+        // the kind to a function if the name refers to a function in the current environment.
+        let mut substitute = None;
+        match &node.kind {
+            HirReferenceSymbol::Local(local) => {
+                // See if the name resolves to a local let-binding or a function name.
+                let is_local_reference = cx.find_let_binding(local.name).is_some();
+                let is_function_reference =
+                    cx.signature.query_function_by_name(local.name).is_some();
 
-        // If this surely points to a function (remember let-bindings take priority because they
-        // may shadow a function), we can add metadata to the expression.
-        let is_definitely_function = is_function_reference && !is_local_reference;
-        if is_definitely_function {
-            // TODO: This vec![] should be filled if we ever support stuff like let k = id::<i32>
-            node.kind = HirReferenceSymbol::new_function(node.name, node.name_span, vec![]);
+                // If this surely points to a function (remember let-bindings take priority because they
+                // may shadow a function), we can add metadata to the expression.
+                let is_definitely_function = is_function_reference && !is_local_reference;
+                if is_definitely_function {
+                    // TODO: This vec![] should be filled if we ever support stuff like let k = id::<i32>
+                    substitute = Some(HirReferenceSymbol::new_function(
+                        local.name,
+                        local.name_span,
+                        vec![],
+                    ));
+                }
+                // If we don't know where this name comes from, we have a type error.
+                if !is_local_reference && !is_function_reference {
+                    return Err(HirError::InvalidReference(InvalidReferenceError {
+                        name: local.name.to_owned(),
+                        span: local.name_span,
+                    }));
+                }
+            }
+            // If any of these show up, we don't have to do anything specific based on the current
+            // environment, and we can directly pass it down to inference.
+            HirReferenceSymbol::Function(_) => {}
+            HirReferenceSymbol::Intrinsic(_) => {}
+            HirReferenceSymbol::TraitMethod(_) => {}
         }
-        // If we don't know where this name comes from, we have a type error.
-        if !is_local_reference && !is_function_reference {
-            return Err(HirError::InvalidReference(InvalidReferenceError {
-                name: node.name.to_owned(),
-                span: node.name_span,
-            }));
+        if let Some(substitute) = substitute {
+            node.kind = substitute;
         }
+        Self::enter_reference_symbol(cx, &mut node.kind)?;
         cx.infer_reference_expr(node, node.ty)?;
         Ok(())
     }
@@ -577,6 +599,7 @@ impl HirModuleTypeCheckerPass {
         node: &mut HirReferenceExpr<'hir>,
     ) -> HirResult<()> {
         node.ty = cx.substitute(node.ty)?;
+        Self::leave_reference_symbol(cx, &mut node.kind)?;
         Ok(())
     }
 
@@ -598,7 +621,7 @@ impl HirModuleTypeCheckerPass {
                     *argument = Self::visit_type(cx, argument)?;
                 }
             }
-            HirReferenceSymbol::Local => {}
+            HirReferenceSymbol::Local(_) => {}
             // These are constructed post-unification, so there is no way for these to be
             // constructed before.
             HirReferenceSymbol::Intrinsic(_) => ice!("cannot visit intrinsic callable symbol"),
@@ -624,7 +647,7 @@ impl HirModuleTypeCheckerPass {
                     *argument = cx.substitute(argument)?;
                 }
             }
-            HirReferenceSymbol::Local | HirReferenceSymbol::Intrinsic(_) => {}
+            HirReferenceSymbol::Local(_) | HirReferenceSymbol::Intrinsic(_) => {}
         }
         Ok(())
     }

--- a/compiler/eight-middle/src/hir_type_check_pass/typing_context.rs
+++ b/compiler/eight-middle/src/hir_type_check_pass/typing_context.rs
@@ -242,7 +242,7 @@ impl<'hir> TypingContext<'hir> {
         expectation: &'hir HirTy<'hir>,
     ) -> HirResult<()> {
         match &expr.kind {
-            HirReferenceSymbol::Local => self.infer_local_reference(expr, expectation),
+            HirReferenceSymbol::Local(_) => self.infer_local_reference(expr, expectation),
             HirReferenceSymbol::Function(_) => self.infer_function_reference(expr, expectation),
             HirReferenceSymbol::TraitMethod(_) => {
                 self.infer_trait_method_reference(expr, expectation)
@@ -258,11 +258,13 @@ impl<'hir> TypingContext<'hir> {
         expr: &mut HirReferenceExpr<'hir>,
         expectation: &'hir HirTy<'hir>,
     ) -> HirResult<()> {
-        assert!(matches!(expr.kind, HirReferenceSymbol::Local));
-        let Some(local_ty) = self.find_let_binding(expr.name) else {
+        let HirReferenceSymbol::Local(local) = &mut expr.kind else {
             ice!("called infer() on a name that doesn't exist in the context");
         };
-        self.constrain_eq(expectation, local_ty, expr.span, expr.name_span);
+        let Some(local_ty) = self.find_let_binding(local.name) else {
+            ice!("called infer() on a name that doesn't exist in the context");
+        };
+        self.constrain_eq(expectation, local_ty, expr.span, local.name_span);
         Ok(())
     }
 
@@ -555,7 +557,9 @@ impl<'hir> TypingContext<'hir> {
             HirReferenceSymbol::Intrinsic(_) => {
                 ice!("cannot infer call() type of intrinsic callable symbol")
             }
-            HirReferenceSymbol::Local => ice!("cannot infer call() type of local callable symbol"),
+            HirReferenceSymbol::Local(_) => {
+                ice!("cannot infer call() type of local callable symbol")
+            }
         }
     }
 

--- a/compiler/eight-middle/src/hir_type_check_pass/typing_context.rs
+++ b/compiler/eight-middle/src/hir_type_check_pass/typing_context.rs
@@ -1,9 +1,8 @@
 use crate::context::CompileContext;
 use crate::hir::{
-    HirAddressOfExpr, HirAssignExpr, HirBooleanLiteralExpr, HirCallExpr, HirCallableReferenceExpr,
-    HirCallableSymbol, HirConstantIndexExpr, HirConstructExpr, HirDerefExpr, HirExpr,
-    HirFunctionTy, HirGroupExpr, HirIntegerLiteralExpr, HirMetaTy, HirModuleSignature,
-    HirOffsetIndexExpr, HirReferenceExpr, HirTy,
+    HirAddressOfExpr, HirAssignExpr, HirBooleanLiteralExpr, HirCallExpr, HirConstantIndexExpr,
+    HirConstructExpr, HirDerefExpr, HirExpr, HirFunctionTy, HirGroupExpr, HirIntegerLiteralExpr,
+    HirMetaTy, HirModuleSignature, HirOffsetIndexExpr, HirReferenceExpr, HirReferenceSymbol, HirTy,
 };
 use crate::hir_type_check_pass::{
     Constraint, DereferenceableConstraint, EqualityConstraint, FieldProjectionConstraint,
@@ -242,6 +241,24 @@ impl<'hir> TypingContext<'hir> {
         expr: &mut HirReferenceExpr<'hir>,
         expectation: &'hir HirTy<'hir>,
     ) -> HirResult<()> {
+        match &expr.kind {
+            HirReferenceSymbol::Local => self.infer_local_reference(expr, expectation),
+            HirReferenceSymbol::Function(_) => self.infer_function_reference(expr, expectation),
+            HirReferenceSymbol::TraitMethod(_) => {
+                self.infer_trait_method_reference(expr, expectation)
+            }
+            HirReferenceSymbol::Intrinsic(_) => {
+                ice!("cannot infer type of intrinsic callable symbol")
+            }
+        }
+    }
+
+    pub fn infer_local_reference(
+        &mut self,
+        expr: &mut HirReferenceExpr<'hir>,
+        expectation: &'hir HirTy<'hir>,
+    ) -> HirResult<()> {
+        assert!(matches!(expr.kind, HirReferenceSymbol::Local));
         let Some(local_ty) = self.find_let_binding(expr.name) else {
             ice!("called infer() on a name that doesn't exist in the context");
         };
@@ -249,28 +266,12 @@ impl<'hir> TypingContext<'hir> {
         Ok(())
     }
 
-    pub fn infer_callable_reference_expr(
+    fn infer_function_reference(
         &mut self,
-        expr: &mut HirCallableReferenceExpr<'hir>,
+        expr: &mut HirReferenceExpr<'hir>,
         expectation: &'hir HirTy<'hir>,
     ) -> HirResult<()> {
-        match &expr.symbol {
-            HirCallableSymbol::Function(_) => {
-                self.infer_function_callable_reference_expr(expr, expectation)
-            }
-            HirCallableSymbol::TraitFunction(_) => {
-                self.infer_trait_function_callable_reference_expr(expr, expectation)
-            }
-            HirCallableSymbol::Intrinsic(_) => ice!("cannot infer type of intrinsic callable symbol"),
-        }
-    }
-
-    fn infer_function_callable_reference_expr(
-        &mut self,
-        expr: &mut HirCallableReferenceExpr<'hir>,
-        expectation: &'hir HirTy<'hir>,
-    ) -> HirResult<()> {
-        let HirCallableSymbol::Function(sym) = &mut expr.symbol else {
+        let HirReferenceSymbol::Function(sym) = &mut expr.kind else {
             ice!(
                 "called infer_function_callable_reference_expr() on non-function symbol reference"
             );
@@ -325,12 +326,12 @@ impl<'hir> TypingContext<'hir> {
         Ok(())
     }
 
-    fn infer_trait_function_callable_reference_expr(
+    fn infer_trait_method_reference(
         &mut self,
-        expr: &mut HirCallableReferenceExpr<'hir>,
+        expr: &mut HirReferenceExpr<'hir>,
         expectation: &'hir HirTy<'hir>,
     ) -> HirResult<()> {
-        let HirCallableSymbol::TraitFunction(sym) = &mut expr.symbol else {
+        let HirReferenceSymbol::TraitMethod(sym) = &mut expr.kind else {
             ice!("called infer_trait_function_callable_reference_expr() on non-trait function symbol reference");
         };
         let Some(trait_signature) = self.signature.query_trait_by_name(sym.trait_name) else {
@@ -423,11 +424,11 @@ impl<'hir> TypingContext<'hir> {
         expr: &mut HirCallExpr<'hir>,
         expectation: &'hir HirTy<'hir>,
     ) -> HirResult<()> {
-        let HirExpr::CallableReference(callee) = expr.callee.as_ref() else {
+        let HirExpr::Reference(callee) = expr.callee.as_ref() else {
             ice!("managed to call an expression that was not reduced into a callable reference");
         };
-        match &callee.symbol {
-            HirCallableSymbol::Function(sym) => {
+        match &callee.kind {
+            HirReferenceSymbol::Function(sym) => {
                 // This should not have anything in the trait type arguments
                 assert!(expr.trait_type_arguments.is_empty());
                 // If the user provided type parameters, we need to constrain them to be equal to the types
@@ -481,7 +482,7 @@ impl<'hir> TypingContext<'hir> {
                 self.constrain_eq(expectation, expr.ty, expr.span, expr.callee.span());
                 Ok(())
             }
-            HirCallableSymbol::TraitFunction(sym) => {
+            HirReferenceSymbol::TraitMethod(sym) => {
                 // TODO: Add proper diagnostics here
                 assert!(
                     expr.trait_type_arguments.is_empty()
@@ -551,7 +552,10 @@ impl<'hir> TypingContext<'hir> {
                 );
                 Ok(())
             }
-            HirCallableSymbol::Intrinsic(_) => ice!("cannot infer type of intrinsic callable symbol"),
+            HirReferenceSymbol::Intrinsic(_) => {
+                ice!("cannot infer call() type of intrinsic callable symbol")
+            }
+            HirReferenceSymbol::Local => ice!("cannot infer call() type of local callable symbol"),
         }
     }
 
@@ -675,7 +679,6 @@ impl<'hir> TypingContext<'hir> {
             HirExpr::BooleanLiteral(e) => self.infer_boolean_literal_expr(e, expectation),
             HirExpr::Assign(e) => self.infer_assign_expr(e, expectation),
             HirExpr::Reference(e) => self.infer_reference_expr(e, expectation),
-            HirExpr::CallableReference(e) => self.infer_callable_reference_expr(e, expectation),
             HirExpr::OffsetIndex(e) => self.infer_offset_index_expr(e, expectation),
             HirExpr::ConstantIndex(e) => self.infer_constant_index_expr(e, expectation),
             HirExpr::Call(e) => self.infer_call_expr(e, expectation),

--- a/compiler/eight-middle/src/hir_type_check_pass/typing_context.rs
+++ b/compiler/eight-middle/src/hir_type_check_pass/typing_context.rs
@@ -261,6 +261,7 @@ impl<'hir> TypingContext<'hir> {
             HirCallableSymbol::TraitFunction(_) => {
                 self.infer_trait_function_callable_reference_expr(expr, expectation)
             }
+            HirCallableSymbol::Intrinsic(_) => ice!("cannot infer type of intrinsic callable symbol"),
         }
     }
 
@@ -550,6 +551,7 @@ impl<'hir> TypingContext<'hir> {
                 );
                 Ok(())
             }
+            HirCallableSymbol::Intrinsic(_) => ice!("cannot infer type of intrinsic callable symbol"),
         }
     }
 


### PR DESCRIPTION
Simplifies AST and we don't do this wonky substitution anymore.