### PR TITLE
feat: restructure name and span of local reference

### DIFF
--- a/compiler/eight-middle/src/ast_lowering_pass/mod.rs
+++ b/compiler/eight-middle/src/ast_lowering_pass/mod.rs
@@ -1,9 +1,10 @@
 use crate::context::CompileContext;
 use crate::hir::{
     HirConstructExprArgument, HirExpr, HirExprStmt, HirFunction, HirFunctionParameterSignature,
-    HirFunctionSignature, HirInstance, HirInstanceSignature, HirLetStmt, HirModule, HirModuleBody,
-    HirModuleSignature, HirStmt, HirStruct, HirStructFieldSignature, HirStructSignature, HirTrait,
-    HirTraitSignature, HirType, HirTypeParameterSignature, HirTypeSignature,
+    HirFunctionSignature, HirInstance, HirInstanceSignature, HirLetStmt, HirLocalReferenceSymbol,
+    HirModule, HirModuleBody, HirModuleSignature, HirStmt, HirStruct, HirStructFieldSignature,
+    HirStructSignature, HirTrait, HirTraitSignature, HirType, HirTypeParameterSignature,
+    HirTypeSignature,
 };
 use crate::hir::{HirReferenceSymbol, HirTy};
 use crate::hir_builder::HirBuilder;
@@ -239,15 +240,8 @@ impl<'ast, 'hir> AstLoweringPass<'ast, 'hir> {
             node.op_span,
             vec![],
         );
-        let reference = HirBuilder::build_reference_expr(
-            node.span,
-            // TODO: This is a placeholder name. The node needs restructuring around this, as this
-            //  should not even be required to be here.
-            self.cc.intern_str("__placeholder__"),
-            node.operand.span(),
-            self.cc.hir_uninitialized_type(),
-            symbol,
-        );
+        let reference =
+            HirBuilder::build_reference_expr(node.span, self.cc.hir_uninitialized_type(), symbol);
         Ok(HirExpr::Call(HirBuilder::build_call_expr(
             node.span,
             HirExpr::Reference(reference),
@@ -287,15 +281,8 @@ impl<'ast, 'hir> AstLoweringPass<'ast, 'hir> {
             node.op_span,
             vec![],
         );
-        let reference = HirBuilder::build_reference_expr(
-            node.span,
-            // TODO: This is a placeholder name. The node needs restructuring around this, as this
-            //  should not even be required to be here.
-            self.cc.intern_str("__placeholder__"),
-            node.lhs.span(),
-            self.cc.hir_uninitialized_type(),
-            symbol,
-        );
+        let reference =
+            HirBuilder::build_reference_expr(node.span, self.cc.hir_uninitialized_type(), symbol);
         Ok(HirExpr::Call(HirBuilder::build_call_expr(
             node.span,
             HirExpr::Reference(reference),
@@ -341,12 +328,13 @@ impl<'ast, 'hir> AstLoweringPass<'ast, 'hir> {
     ) -> HirResult<HirExpr<'hir>> {
         Ok(HirExpr::Reference(HirBuilder::build_reference_expr(
             node.span,
-            self.cc.intern_str(&node.name.name),
-            node.name.span,
             self.cc.hir_uninitialized_type(),
             // Assume that it is a local reference by default. The value here does not really matter
             // as the type checker will replace this as it sees fit.
-            HirReferenceSymbol::Local,
+            HirReferenceSymbol::Local(HirLocalReferenceSymbol {
+                name: self.cc.intern_str(&node.name.name),
+                name_span: node.name.span,
+            }),
         )))
     }
 

--- a/compiler/eight-middle/src/hir.rs
+++ b/compiler/eight-middle/src/hir.rs
@@ -96,8 +96,6 @@ pub struct HirDerefExpr<'hir> {
 #[derive(Debug)]
 pub struct HirReferenceExpr<'hir> {
     pub span: Span,
-    pub name: &'hir str,
-    pub name_span: Span,
     /// The type of `name` in the current scope.
     pub ty: &'hir HirTy<'hir>,
     pub kind: HirReferenceSymbol<'hir>,
@@ -148,10 +146,16 @@ impl HirReferenceSymbol<'_> {
 /// requiring to have an undecided variant.
 #[derive(Debug)]
 pub enum HirReferenceSymbol<'hir> {
-    Local,
+    Local(HirLocalReferenceSymbol<'hir>),
     Function(HirFunctionReferenceSymbol<'hir>),
     TraitMethod(HirTraitMethodReferenceSymbol<'hir>),
     Intrinsic(CompilerIntrinsic),
+}
+
+#[derive(Debug)]
+pub struct HirLocalReferenceSymbol<'hir> {
+    pub name: &'hir str,
+    pub name_span: Span,
 }
 
 #[derive(Debug)]

--- a/compiler/eight-middle/src/hir_builder.rs
+++ b/compiler/eight-middle/src/hir_builder.rs
@@ -315,17 +315,9 @@ impl<'hir> HirBuilder {
 
     pub fn build_reference_expr(
         span: Span,
-        name: &'hir str,
-        name_span: Span,
         ty: &'hir HirTy<'hir>,
         kind: HirReferenceSymbol<'hir>,
     ) -> HirReferenceExpr<'hir> {
-        HirReferenceExpr {
-            span,
-            name,
-            name_span,
-            ty,
-            kind,
-        }
+        HirReferenceExpr { span, ty, kind }
     }
 }

--- a/compiler/eight-middle/src/hir_lowering_pass/mod.rs
+++ b/compiler/eight-middle/src/hir_lowering_pass/mod.rs
@@ -213,9 +213,9 @@ impl<'hir, 'mir> MirModuleLoweringPass<'mir> {
         expr: &'hir HirReferenceExpr<'hir>,
     ) -> MirResult<MirValueId> {
         match &expr.kind {
-            HirReferenceSymbol::Local => {
-                let id = self.locals.find(&expr.name).unwrap_or_else(|| {
-                    ice!("failed to find local value for {}", expr.name);
+            HirReferenceSymbol::Local(local) => {
+                let id = self.locals.find(&local.name).unwrap_or_else(|| {
+                    ice!("failed to find local value for {}", local.name);
                 });
                 let value_ty = b.data().get_value_type(*id);
                 let expected_ty = self.visit_ty(expr.ty)?;

--- a/compiler/eight-middle/src/hir_textual_pass/mod.rs
+++ b/compiler/eight-middle/src/hir_textual_pass/mod.rs
@@ -623,7 +623,7 @@ impl<'a> HirModuleTextualPass<'a> {
         expr: &'hir HirReferenceExpr,
     ) -> DocBuilder<'a, Arena<'a>> {
         match &expr.kind {
-            HirReferenceSymbol::Local => self.arena.text(expr.name),
+            HirReferenceSymbol::Local(s) => self.arena.text(s.name),
             HirReferenceSymbol::Function(s) => self
                 .arena
                 .text(s.name)

--- a/compiler/eight-middle/src/hir_type_check_pass/mod.rs
+++ b/compiler/eight-middle/src/hir_type_check_pass/mod.rs
@@ -549,24 +549,46 @@ impl HirModuleTypeCheckerPass {
         node: &mut HirReferenceExpr<'hir>,
     ) -> HirResult<()> {
         node.ty = Self::visit_type(cx, node.ty)?;
-        // See if the name resolves to a local let-binding or a function name.
-        let is_local_reference = cx.find_let_binding(node.name).is_some();
-        let is_function_reference = cx.signature.query_function_by_name(node.name).is_some();
+        // When nodes arrive from AST lowering, local kinds are assumed to be unknown unless proven
+        // otherwise. This means that if we come across a local reference, we might have to change
+        // the kind to a function if the name refers to a function in the current environment.
+        let mut substitute = None;
+        match &node.kind {
+            HirReferenceSymbol::Local(local) => {
+                // See if the name resolves to a local let-binding or a function name.
+                let is_local_reference = cx.find_let_binding(local.name).is_some();
+                let is_function_reference =
+                    cx.signature.query_function_by_name(local.name).is_some();
 
-        // If this surely points to a function (remember let-bindings take priority because they
-        // may shadow a function), we can add metadata to the expression.
-        let is_definitely_function = is_function_reference && !is_local_reference;
-        if is_definitely_function {
-            // TODO: This vec![] should be filled if we ever support stuff like let k = id::<i32>
-            node.kind = HirReferenceSymbol::new_function(node.name, node.name_span, vec![]);
+                // If this surely points to a function (remember let-bindings take priority because they
+                // may shadow a function), we can add metadata to the expression.
+                let is_definitely_function = is_function_reference && !is_local_reference;
+                if is_definitely_function {
+                    // TODO: This vec![] should be filled if we ever support stuff like let k = id::<i32>
+                    substitute = Some(HirReferenceSymbol::new_function(
+                        local.name,
+                        local.name_span,
+                        vec![],
+                    ));
+                }
+                // If we don't know where this name comes from, we have a type error.
+                if !is_local_reference && !is_function_reference {
+                    return Err(HirError::InvalidReference(InvalidReferenceError {
+                        name: local.name.to_owned(),
+                        span: local.name_span,
+                    }));
+                }
+            }
+            // If any of these show up, we don't have to do anything specific based on the current
+            // environment, and we can directly pass it down to inference.
+            HirReferenceSymbol::Function(_) => {}
+            HirReferenceSymbol::Intrinsic(_) => {}
+            HirReferenceSymbol::TraitMethod(_) => {}
         }
-        // If we don't know where this name comes from, we have a type error.
-        if !is_local_reference && !is_function_reference {
-            return Err(HirError::InvalidReference(InvalidReferenceError {
-                name: node.name.to_owned(),
-                span: node.name_span,
-            }));
+        if let Some(substitute) = substitute {
+            node.kind = substitute;
         }
+        Self::enter_reference_symbol(cx, &mut node.kind)?;
         cx.infer_reference_expr(node, node.ty)?;
         Ok(())
     }
@@ -577,6 +599,7 @@ impl HirModuleTypeCheckerPass {
         node: &mut HirReferenceExpr<'hir>,
     ) -> HirResult<()> {
         node.ty = cx.substitute(node.ty)?;
+        Self::leave_reference_symbol(cx, &mut node.kind)?;
         Ok(())
     }
 
@@ -598,7 +621,7 @@ impl HirModuleTypeCheckerPass {
                     *argument = Self::visit_type(cx, argument)?;
                 }
             }
-            HirReferenceSymbol::Local => {}
+            HirReferenceSymbol::Local(_) => {}
             // These are constructed post-unification, so there is no way for these to be
             // constructed before.
             HirReferenceSymbol::Intrinsic(_) => ice!("cannot visit intrinsic callable symbol"),
@@ -624,7 +647,7 @@ impl HirModuleTypeCheckerPass {
                     *argument = cx.substitute(argument)?;
                 }
             }
-            HirReferenceSymbol::Local | HirReferenceSymbol::Intrinsic(_) => {}
+            HirReferenceSymbol::Local(_) | HirReferenceSymbol::Intrinsic(_) => {}
         }
         Ok(())
     }

--- a/compiler/eight-middle/src/hir_type_check_pass/typing_context.rs
+++ b/compiler/eight-middle/src/hir_type_check_pass/typing_context.rs
@@ -242,7 +242,7 @@ impl<'hir> TypingContext<'hir> {
         expectation: &'hir HirTy<'hir>,
     ) -> HirResult<()> {
         match &expr.kind {
-            HirReferenceSymbol::Local => self.infer_local_reference(expr, expectation),
+            HirReferenceSymbol::Local(_) => self.infer_local_reference(expr, expectation),
             HirReferenceSymbol::Function(_) => self.infer_function_reference(expr, expectation),
             HirReferenceSymbol::TraitMethod(_) => {
                 self.infer_trait_method_reference(expr, expectation)
@@ -258,11 +258,13 @@ impl<'hir> TypingContext<'hir> {
         expr: &mut HirReferenceExpr<'hir>,
         expectation: &'hir HirTy<'hir>,
     ) -> HirResult<()> {
-        assert!(matches!(expr.kind, HirReferenceSymbol::Local));
-        let Some(local_ty) = self.find_let_binding(expr.name) else {
+        let HirReferenceSymbol::Local(local) = &mut expr.kind else {
             ice!("called infer() on a name that doesn't exist in the context");
         };
-        self.constrain_eq(expectation, local_ty, expr.span, expr.name_span);
+        let Some(local_ty) = self.find_let_binding(local.name) else {
+            ice!("called infer() on a name that doesn't exist in the context");
+        };
+        self.constrain_eq(expectation, local_ty, expr.span, local.name_span);
         Ok(())
     }
 
@@ -555,7 +557,9 @@ impl<'hir> TypingContext<'hir> {
             HirReferenceSymbol::Intrinsic(_) => {
                 ice!("cannot infer call() type of intrinsic callable symbol")
             }
-            HirReferenceSymbol::Local => ice!("cannot infer call() type of local callable symbol"),
+            HirReferenceSymbol::Local(_) => {
+                ice!("cannot infer call() type of local callable symbol")
+            }
         }
     }
 


### PR DESCRIPTION
Intrinsics and trait methods do not have a single qualified name, so
moving this into Local makes a lot more sense. This allows for better
invariants in the type checker.