### PR TITLE
feat: simplify builtin trait operations to compiler intrinsics

### DIFF
--- a/compiler/eight-middle/src/builtin.rs
+++ b/compiler/eight-middle/src/builtin.rs
@@ -1,5 +1,7 @@
 //! Utilities for built-in compiler functions.
 
+use crate::context::CompileContext;
+use crate::hir::HirTy;
 use std::fmt::Display;
 
 /// A binary operator that is to be lowered using compiler intrinsics.
@@ -30,6 +32,48 @@ pub enum CompilerIntrinsic {
     BooleanNeq,
     IntegerNeg,
     BooleanNot,
+}
+
+impl<'hir> CompilerIntrinsic {
+    pub fn get_application_type(&self, cc: &'hir CompileContext<'hir>) -> &'hir HirTy<'hir> {
+        match self {
+            // Intrinsics of type fn(i32, i32) -> i32
+            CompilerIntrinsic::IntegerAdd
+            | CompilerIntrinsic::IntegerSub
+            | CompilerIntrinsic::IntegerMul
+            | CompilerIntrinsic::IntegerDiv
+            | CompilerIntrinsic::IntegerRem => cc.hir_function_type(
+                cc.hir_integer32_type(),
+                vec![cc.hir_integer32_type(), cc.hir_integer32_type()],
+            ),
+            // Intrinsics of type fn(i32, i32) -> bool
+            CompilerIntrinsic::IntegerEq
+            | CompilerIntrinsic::IntegerNeq
+            | CompilerIntrinsic::IntegerLt
+            | CompilerIntrinsic::IntegerGt
+            | CompilerIntrinsic::IntegerLte
+            | CompilerIntrinsic::IntegerGte => cc.hir_function_type(
+                cc.hir_boolean_type(),
+                vec![cc.hir_integer32_type(), cc.hir_integer32_type()],
+            ),
+            // Intrinsics of type fn(bool, bool) -> bool
+            CompilerIntrinsic::BooleanAnd
+            | CompilerIntrinsic::BooleanOr
+            | CompilerIntrinsic::BooleanEq
+            | CompilerIntrinsic::BooleanNeq => cc.hir_function_type(
+                cc.hir_boolean_type(),
+                vec![cc.hir_boolean_type(), cc.hir_boolean_type()],
+            ),
+            // Intrinsics of type fn(i32) -> i32
+            CompilerIntrinsic::IntegerNeg => {
+                cc.hir_function_type(cc.hir_integer32_type(), vec![cc.hir_integer32_type()])
+            }
+            // Intrinsics of type fn(bool) -> bool
+            CompilerIntrinsic::BooleanNot => {
+                cc.hir_function_type(cc.hir_boolean_type(), vec![cc.hir_boolean_type()])
+            }
+        }
+    }
 }
 
 impl Display for CompilerIntrinsic {

--- a/compiler/eight-middle/src/hir.rs
+++ b/compiler/eight-middle/src/hir.rs
@@ -101,38 +101,6 @@ pub struct HirReferenceExpr<'hir> {
     pub kind: HirReferenceSymbol<'hir>,
 }
 
-impl HirReferenceSymbol<'_> {
-    /// Try to convert this callable reference into a compiler intrinsic.
-    #[rustfmt::skip]
-    pub fn get_compiler_intrinsic_candidate(&self) -> Option<CompilerIntrinsic> {
-        let HirReferenceSymbol::TraitMethod(symbol) = self else {
-            return None
-        };
-        match (symbol.trait_name, symbol.method_name, symbol.method_type_arguments.as_slice()) {
-            // Compiler intrinsics for the i32 type
-            ("Add", "add", &[HirTy::Integer32(_), HirTy::Integer32(_), HirTy::Integer32(_)]) => Some(CompilerIntrinsic::IntegerAdd),
-            ("Sub", "sub", &[HirTy::Integer32(_), HirTy::Integer32(_), HirTy::Integer32(_)]) => Some(CompilerIntrinsic::IntegerSub),
-            ("Mul", "mul", &[HirTy::Integer32(_), HirTy::Integer32(_), HirTy::Integer32(_)]) => Some(CompilerIntrinsic::IntegerMul),
-            ("Div", "div", &[HirTy::Integer32(_), HirTy::Integer32(_), HirTy::Integer32(_)]) => Some(CompilerIntrinsic::IntegerDiv),
-            ("Rem", "rem", &[HirTy::Integer32(_), HirTy::Integer32(_), HirTy::Integer32(_)]) => Some(CompilerIntrinsic::IntegerRem),
-            ("Eq", "eq", &[HirTy::Integer32(_), HirTy::Integer32(_)]) => Some(CompilerIntrinsic::IntegerEq),
-            ("Eq", "neq", &[HirTy::Integer32(_), HirTy::Integer32(_)]) => Some(CompilerIntrinsic::IntegerNeq),
-            ("Ord", "lt", &[HirTy::Integer32(_), HirTy::Integer32(_)]) => Some(CompilerIntrinsic::IntegerLt),
-            ("Ord", "gt", &[HirTy::Integer32(_), HirTy::Integer32(_)]) => Some(CompilerIntrinsic::IntegerGt),
-            ("Ord", "le", &[HirTy::Integer32(_), HirTy::Integer32(_)]) => Some(CompilerIntrinsic::IntegerLte),
-            ("Ord", "ge", &[HirTy::Integer32(_), HirTy::Integer32(_)]) => Some(CompilerIntrinsic::IntegerGte),
-            ("Neg", "neg", &[HirTy::Integer32(_)]) => Some(CompilerIntrinsic::IntegerNeg),
-            // Compiler intrinsics for the bool type
-            ("Not", "not", &[HirTy::Boolean(_)]) => Some(CompilerIntrinsic::BooleanNot),
-            ("Eq", "eq", &[HirTy::Boolean(_), HirTy::Boolean(_)]) => Some(CompilerIntrinsic::BooleanEq),
-            ("Eq", "neq", &[HirTy::Boolean(_), HirTy::Boolean(_)]) => Some(CompilerIntrinsic::BooleanNeq),
-            ("And", "and", &[HirTy::Boolean(_), HirTy::Boolean(_)]) => Some(CompilerIntrinsic::BooleanAnd),
-            ("Or", "or", &[HirTy::Boolean(_), HirTy::Boolean(_)]) => Some(CompilerIntrinsic::BooleanOr),
-            _ => None
-        }
-    }
-}
-
 /// A reference to a symbol.
 ///
 /// A reference can be resolved into one of four categories:
@@ -150,34 +118,6 @@ pub enum HirReferenceSymbol<'hir> {
     Function(HirFunctionReferenceSymbol<'hir>),
     TraitMethod(HirTraitMethodReferenceSymbol<'hir>),
     Intrinsic(CompilerIntrinsic),
-}
-
-#[derive(Debug)]
-pub struct HirLocalReferenceSymbol<'hir> {
-    pub name: &'hir str,
-    pub name_span: Span,
-}
-
-#[derive(Debug)]
-pub struct HirFunctionReferenceSymbol<'hir> {
-    pub name: &'hir str,
-    pub name_span: Span,
-    /// The type arguments that the callable reference was instantiated with.
-    ///
-    /// These are unknown to begin with, but can be filled in after unification.
-    pub type_arguments: Vec<&'hir HirTy<'hir>>,
-    pub instantiated_call_parameters: Vec<&'hir HirTy<'hir>>,
-}
-
-#[derive(Debug)]
-pub struct HirTraitMethodReferenceSymbol<'hir> {
-    pub trait_name: &'hir str,
-    pub trait_name_span: Span,
-    pub trait_type_arguments: Vec<&'hir HirTy<'hir>>,
-    pub method_name: &'hir str,
-    pub method_name_span: Span,
-    pub method_type_arguments: Vec<&'hir HirTy<'hir>>,
-    pub instantiated_call_parameters: Vec<&'hir HirTy<'hir>>,
 }
 
 impl<'hir> HirReferenceSymbol<'hir> {
@@ -211,6 +151,63 @@ impl<'hir> HirReferenceSymbol<'hir> {
             method_type_arguments,
             instantiated_call_parameters: Vec::new(),
         })
+    }
+}
+
+#[derive(Debug)]
+pub struct HirLocalReferenceSymbol<'hir> {
+    pub name: &'hir str,
+    pub name_span: Span,
+}
+
+#[derive(Debug)]
+pub struct HirFunctionReferenceSymbol<'hir> {
+    pub name: &'hir str,
+    pub name_span: Span,
+    /// The type arguments that the callable reference was instantiated with.
+    ///
+    /// These are unknown to begin with, but can be filled in after unification.
+    pub type_arguments: Vec<&'hir HirTy<'hir>>,
+    pub instantiated_call_parameters: Vec<&'hir HirTy<'hir>>,
+}
+
+#[derive(Debug)]
+pub struct HirTraitMethodReferenceSymbol<'hir> {
+    pub trait_name: &'hir str,
+    pub trait_name_span: Span,
+    pub trait_type_arguments: Vec<&'hir HirTy<'hir>>,
+    pub method_name: &'hir str,
+    pub method_name_span: Span,
+    pub method_type_arguments: Vec<&'hir HirTy<'hir>>,
+    pub instantiated_call_parameters: Vec<&'hir HirTy<'hir>>,
+}
+
+impl HirTraitMethodReferenceSymbol<'_> {
+    /// Try to convert this callable reference into a compiler intrinsic.
+    #[rustfmt::skip]
+    pub fn get_compiler_intrinsic_candidate(&self) -> Option<CompilerIntrinsic> {
+        match (self.trait_name, self.method_name, self.trait_type_arguments.as_slice()) {
+            // Compiler intrinsics for the i32 type
+            ("Add", "add", &[HirTy::Integer32(_), HirTy::Integer32(_), HirTy::Integer32(_)]) => Some(CompilerIntrinsic::IntegerAdd),
+            ("Sub", "sub", &[HirTy::Integer32(_), HirTy::Integer32(_), HirTy::Integer32(_)]) => Some(CompilerIntrinsic::IntegerSub),
+            ("Mul", "mul", &[HirTy::Integer32(_), HirTy::Integer32(_), HirTy::Integer32(_)]) => Some(CompilerIntrinsic::IntegerMul),
+            ("Div", "div", &[HirTy::Integer32(_), HirTy::Integer32(_), HirTy::Integer32(_)]) => Some(CompilerIntrinsic::IntegerDiv),
+            ("Rem", "rem", &[HirTy::Integer32(_), HirTy::Integer32(_), HirTy::Integer32(_)]) => Some(CompilerIntrinsic::IntegerRem),
+            ("Eq", "eq", &[HirTy::Integer32(_), HirTy::Integer32(_)]) => Some(CompilerIntrinsic::IntegerEq),
+            ("Eq", "neq", &[HirTy::Integer32(_), HirTy::Integer32(_)]) => Some(CompilerIntrinsic::IntegerNeq),
+            ("Ord", "lt", &[HirTy::Integer32(_), HirTy::Integer32(_)]) => Some(CompilerIntrinsic::IntegerLt),
+            ("Ord", "gt", &[HirTy::Integer32(_), HirTy::Integer32(_)]) => Some(CompilerIntrinsic::IntegerGt),
+            ("Ord", "le", &[HirTy::Integer32(_), HirTy::Integer32(_)]) => Some(CompilerIntrinsic::IntegerLte),
+            ("Ord", "ge", &[HirTy::Integer32(_), HirTy::Integer32(_)]) => Some(CompilerIntrinsic::IntegerGte),
+            ("Neg", "neg", &[HirTy::Integer32(_)]) => Some(CompilerIntrinsic::IntegerNeg),
+            // Compiler intrinsics for the bool type
+            ("Not", "not", &[HirTy::Boolean(_)]) => Some(CompilerIntrinsic::BooleanNot),
+            ("Eq", "eq", &[HirTy::Boolean(_), HirTy::Boolean(_)]) => Some(CompilerIntrinsic::BooleanEq),
+            ("Eq", "neq", &[HirTy::Boolean(_), HirTy::Boolean(_)]) => Some(CompilerIntrinsic::BooleanNeq),
+            ("And", "and", &[HirTy::Boolean(_), HirTy::Boolean(_)]) => Some(CompilerIntrinsic::BooleanAnd),
+            ("Or", "or", &[HirTy::Boolean(_), HirTy::Boolean(_)]) => Some(CompilerIntrinsic::BooleanOr),
+            _ => None
+        }
     }
 }
 

--- a/compiler/eight-middle/src/hir_simplify_pass/mod.rs
+++ b/compiler/eight-middle/src/hir_simplify_pass/mod.rs
@@ -8,6 +8,8 @@ use crate::hir::{
     HirIntegerLiteralExpr, HirLetStmt, HirLoopStmt, HirModule, HirOffsetIndexExpr,
     HirReferenceExpr, HirReferenceSymbol, HirReturnStmt, HirStmt,
 };
+use crate::hir_builder::HirBuilder;
+use eight_diagnostics::ice;
 
 pub struct HirSimplifyPass<'be> {
     cc: &'be CompileContext<'be>,
@@ -134,10 +136,38 @@ impl<'be> HirSimplifyPass<'be> {
         self.visit_expr(&mut expr.index);
     }
 
+    /// Visit a call expression.
+    ///
+    /// We want to simplify or re-guide calls to functions or trait methods that can be optimized
+    /// or lowered into a more efficient form further down the line by turning them into calls to
+    /// compiler intrinsics.
     pub fn visit_call_expr(&mut self, expr: &mut HirCallExpr<'be>) {
         self.visit_expr(&mut expr.callee);
         for argument in expr.arguments.iter_mut() {
             self.visit_expr(argument);
+        }
+        // TODO: The compiler will currently not emit this, but in the future we might support
+        //   calling arbitrary pointers, in which case this should be valid.
+        let HirExpr::Reference(reference) = expr.callee.as_mut() else {
+            return;
+        };
+        // Potentially substitute the call with a compiler intrinsic.
+        let mut substitute = None;
+        match &reference.kind {
+            HirReferenceSymbol::TraitMethod(symbol) => {
+                if let Some(intrinsic) = symbol.get_compiler_intrinsic_candidate() {
+                    substitute = Some(intrinsic)
+                }
+            }
+            HirReferenceSymbol::Function(_) | HirReferenceSymbol::Intrinsic(_) => {}
+            HirReferenceSymbol::Local(_) => ice!("invoked call to a local variable"),
+        }
+        if let Some(substitute) = substitute {
+            expr.callee = Box::new(HirExpr::Reference(HirBuilder::build_reference_expr(
+                expr.span,
+                substitute.get_application_type(self.cc),
+                HirReferenceSymbol::Intrinsic(substitute),
+            )))
         }
     }
 

--- a/compiler/eight-tests/tests/snapshots/hir/compiler_tests__hir@fma.test.snap
+++ b/compiler/eight-tests/tests/snapshots/hir/compiler_tests__hir@fma.test.snap
@@ -67,14 +67,14 @@ hir_module {
     // module functions
     fn vec512_fma<>(x: vec512, y: vec512, acc: vec512) -> vec512 {
       let vs: vec512 = (new vec512 {
-        vs: ((malloc::<i32> as fn(i32)->*i32)(((Div<i32,i32,i32>::div::<> as fn(i32, i32)->i32)((512 as i32),(4 as i32)) as i32)) as *i32),
+        vs: ((malloc::<i32> as fn(i32)->*i32)(((@@builtin_i32_div as fn(i32, i32)->i32)((512 as i32),(4 as i32)) as i32)) as *i32),
       } as vec512);
       {
         let i: i32 = (0 as i32);
         loop {
-          if (((Ord<i32,i32>::lt::<> as fn(i32, i32)->bool)((i as i32),((Div<i32,i32,i32>::div::<> as fn(i32, i32)->i32)((512 as i32),(4 as i32)) as i32)) as bool)){
-            ((((vs as vec512).vs as *i32)[(i as i32)] as i32) = ((Add<i32,i32,i32>::add::<> as fn(i32, i32)->i32)(((Mul<i32,i32,i32>::mul::<> as fn(i32, i32)->i32)((((x as vec512).vs as *i32)[(i as i32)] as i32),(((y as vec512).vs as *i32)[(i as i32)] as i32)) as i32),(((acc as vec512).vs as *i32)[(i as i32)] as i32)) as i32) as unit);
-            ((i as i32) = ((Add<i32,i32,i32>::add::<> as fn(i32, i32)->i32)((i as i32),(1 as i32)) as i32) as unit);
+          if (((@builtin_i32_lt as fn(i32, i32)->bool)((i as i32),((@@builtin_i32_div as fn(i32, i32)->i32)((512 as i32),(4 as i32)) as i32)) as bool)){
+            ((((vs as vec512).vs as *i32)[(i as i32)] as i32) = ((@@builtin_i32_add as fn(i32, i32)->i32)(((@@builtin_i32_mul as fn(i32, i32)->i32)((((x as vec512).vs as *i32)[(i as i32)] as i32),(((y as vec512).vs as *i32)[(i as i32)] as i32)) as i32),(((acc as vec512).vs as *i32)[(i as i32)] as i32)) as i32) as unit);
+            ((i as i32) = ((@@builtin_i32_add as fn(i32, i32)->i32)((i as i32),(1 as i32)) as i32) as unit);
           } else {
             break;
           }

--- a/compiler/eight-tests/tests/snapshots/hir/compiler_tests__hir@matmul.test.snap
+++ b/compiler/eight-tests/tests/snapshots/hir/compiler_tests__hir@matmul.test.snap
@@ -71,36 +71,36 @@ hir_module {
       let c: Matrix = (new Matrix {
         r: ((a as Matrix).r as i32),
         c: ((b as Matrix).c as i32),
-        buf: ((malloc::<i32> as fn(i32)->*i32)(((Mul<i32,i32,i32>::mul::<> as fn(i32, i32)->i32)(((a as Matrix).r as i32),((Mul<i32,i32,i32>::mul::<> as fn(i32, i32)->i32)(((b as Matrix).c as i32),(4 as i32)) as i32)) as i32)) as *i32),
+        buf: ((malloc::<i32> as fn(i32)->*i32)(((@@builtin_i32_mul as fn(i32, i32)->i32)(((a as Matrix).r as i32),((@@builtin_i32_mul as fn(i32, i32)->i32)(((b as Matrix).c as i32),(4 as i32)) as i32)) as i32)) as *i32),
       } as Matrix);
       {
         let i: i32 = (0 as i32);
         loop {
-          if (((Ord<i32,i32>::lt::<> as fn(i32, i32)->bool)((i as i32),((a as Matrix).r as i32)) as bool)){
+          if (((@builtin_i32_lt as fn(i32, i32)->bool)((i as i32),((a as Matrix).r as i32)) as bool)){
             {
               let j: i32 = (0 as i32);
               loop {
-                if (((Ord<i32,i32>::lt::<> as fn(i32, i32)->bool)((j as i32),((b as Matrix).c as i32)) as bool)){
+                if (((@builtin_i32_lt as fn(i32, i32)->bool)((j as i32),((b as Matrix).c as i32)) as bool)){
                   let sum: i32 = (0 as i32);
                   {
                     let k: i32 = (0 as i32);
                     loop {
-                      if (((Ord<i32,i32>::lt::<> as fn(i32, i32)->bool)((k as i32),((a as Matrix).c as i32)) as bool)){
-                        ((sum as i32) = ((Add<i32,i32,i32>::add::<> as fn(i32, i32)->i32)((sum as i32),((Mul<i32,i32,i32>::mul::<> as fn(i32, i32)->i32)((((a as Matrix).buf as *i32)[((Add<i32,i32,i32>::add::<> as fn(i32, i32)->i32)(((Mul<i32,i32,i32>::mul::<> as fn(i32, i32)->i32)((i as i32),((a as Matrix).c as i32)) as i32),(k as i32)) as i32)] as i32),(((b as Matrix).buf as *i32)[((Add<i32,i32,i32>::add::<> as fn(i32, i32)->i32)(((Mul<i32,i32,i32>::mul::<> as fn(i32, i32)->i32)((k as i32),((b as Matrix).c as i32)) as i32),(j as i32)) as i32)] as i32)) as i32)) as i32) as unit);
-                        ((k as i32) = ((Add<i32,i32,i32>::add::<> as fn(i32, i32)->i32)((k as i32),(1 as i32)) as i32) as unit);
+                      if (((@builtin_i32_lt as fn(i32, i32)->bool)((k as i32),((a as Matrix).c as i32)) as bool)){
+                        ((sum as i32) = ((@@builtin_i32_add as fn(i32, i32)->i32)((sum as i32),((@@builtin_i32_mul as fn(i32, i32)->i32)((((a as Matrix).buf as *i32)[((@@builtin_i32_add as fn(i32, i32)->i32)(((@@builtin_i32_mul as fn(i32, i32)->i32)((i as i32),((a as Matrix).c as i32)) as i32),(k as i32)) as i32)] as i32),(((b as Matrix).buf as *i32)[((@@builtin_i32_add as fn(i32, i32)->i32)(((@@builtin_i32_mul as fn(i32, i32)->i32)((k as i32),((b as Matrix).c as i32)) as i32),(j as i32)) as i32)] as i32)) as i32)) as i32) as unit);
+                        ((k as i32) = ((@@builtin_i32_add as fn(i32, i32)->i32)((k as i32),(1 as i32)) as i32) as unit);
                       } else {
                         break;
                       }
                     }
                   }
-                  ((((c as Matrix).buf as *i32)[((Add<i32,i32,i32>::add::<> as fn(i32, i32)->i32)(((Mul<i32,i32,i32>::mul::<> as fn(i32, i32)->i32)((i as i32),((b as Matrix).c as i32)) as i32),(j as i32)) as i32)] as i32) = (sum as i32) as unit);
-                  ((j as i32) = ((Add<i32,i32,i32>::add::<> as fn(i32, i32)->i32)((j as i32),(1 as i32)) as i32) as unit);
+                  ((((c as Matrix).buf as *i32)[((@@builtin_i32_add as fn(i32, i32)->i32)(((@@builtin_i32_mul as fn(i32, i32)->i32)((i as i32),((b as Matrix).c as i32)) as i32),(j as i32)) as i32)] as i32) = (sum as i32) as unit);
+                  ((j as i32) = ((@@builtin_i32_add as fn(i32, i32)->i32)((j as i32),(1 as i32)) as i32) as unit);
                 } else {
                   break;
                 }
               }
             }
-            ((i as i32) = ((Add<i32,i32,i32>::add::<> as fn(i32, i32)->i32)((i as i32),(1 as i32)) as i32) as unit);
+            ((i as i32) = ((@@builtin_i32_add as fn(i32, i32)->i32)((i as i32),(1 as i32)) as i32) as unit);
           } else {
             break;
           }

--- a/compiler/eight-tests/tests/snapshots/hir/compiler_tests__hir@quicksort.test.snap
+++ b/compiler/eight-tests/tests/snapshots/hir/compiler_tests__hir@quicksort.test.snap
@@ -61,31 +61,31 @@ hir_module {
     // module functions
     fn partition<>(xs: *i32, l: i32, r: i32) -> i32 {
       let x: i32 = ((xs as *i32)[(r as i32)] as i32);
-      let i: i32 = ((Sub<i32,i32,i32>::sub::<> as fn(i32, i32)->i32)((l as i32),(1 as i32)) as i32);
+      let i: i32 = ((@@builtin_i32_sub as fn(i32, i32)->i32)((l as i32),(1 as i32)) as i32);
       {
         let j: i32 = (l as i32);
         loop {
-          if (((Ord<i32,i32>::lt::<> as fn(i32, i32)->bool)((j as i32),(r as i32)) as bool)){
-            if (((Ord<i32,i32>::le::<> as fn(i32, i32)->bool)(((xs as *i32)[(j as i32)] as i32),(x as i32)) as bool)){
-              ((i as i32) = ((Add<i32,i32,i32>::add::<> as fn(i32, i32)->i32)((i as i32),(1 as i32)) as i32) as unit);
+          if (((@builtin_i32_lt as fn(i32, i32)->bool)((j as i32),(r as i32)) as bool)){
+            if (((@@builtin_i32_lte as fn(i32, i32)->bool)(((xs as *i32)[(j as i32)] as i32),(x as i32)) as bool)){
+              ((i as i32) = ((@@builtin_i32_add as fn(i32, i32)->i32)((i as i32),(1 as i32)) as i32) as unit);
               ((swap::<> as fn(*i32, *i32)->unit)((&((xs as *i32)[(i as i32)] as i32) as *i32),(&((xs as *i32)[(j as i32)] as i32) as *i32)) as unit);
             } else {
             
             }
-            ((j as i32) = ((Add<i32,i32,i32>::add::<> as fn(i32, i32)->i32)((j as i32),(1 as i32)) as i32) as unit);
+            ((j as i32) = ((@@builtin_i32_add as fn(i32, i32)->i32)((j as i32),(1 as i32)) as i32) as unit);
           } else {
             break;
           }
         }
       }
-      ((swap::<> as fn(*i32, *i32)->unit)((&((xs as *i32)[((Add<i32,i32,i32>::add::<> as fn(i32, i32)->i32)((i as i32),(1 as i32)) as i32)] as i32) as *i32),(&((xs as *i32)[(r as i32)] as i32) as *i32)) as unit);
-      return ((Add<i32,i32,i32>::add::<> as fn(i32, i32)->i32)((i as i32),(1 as i32)) as i32);
+      ((swap::<> as fn(*i32, *i32)->unit)((&((xs as *i32)[((@@builtin_i32_add as fn(i32, i32)->i32)((i as i32),(1 as i32)) as i32)] as i32) as *i32),(&((xs as *i32)[(r as i32)] as i32) as *i32)) as unit);
+      return ((@@builtin_i32_add as fn(i32, i32)->i32)((i as i32),(1 as i32)) as i32);
     }
     fn quicksort<>(xs: *i32, l: i32, r: i32) -> unit {
-      if (((Ord<i32,i32>::lt::<> as fn(i32, i32)->bool)((l as i32),(r as i32)) as bool)){
+      if (((@builtin_i32_lt as fn(i32, i32)->bool)((l as i32),(r as i32)) as bool)){
         let p: i32 = ((partition::<> as fn(*i32, i32, i32)->i32)((xs as *i32),(l as i32),(r as i32)) as i32);
-        ((quicksort::<> as fn(*i32, i32, i32)->unit)((xs as *i32),(l as i32),((Sub<i32,i32,i32>::sub::<> as fn(i32, i32)->i32)((p as i32),(1 as i32)) as i32)) as unit);
-        ((quicksort::<> as fn(*i32, i32, i32)->unit)((xs as *i32),((Add<i32,i32,i32>::add::<> as fn(i32, i32)->i32)((p as i32),(1 as i32)) as i32),(r as i32)) as unit);
+        ((quicksort::<> as fn(*i32, i32, i32)->unit)((xs as *i32),(l as i32),((@@builtin_i32_sub as fn(i32, i32)->i32)((p as i32),(1 as i32)) as i32)) as unit);
+        ((quicksort::<> as fn(*i32, i32, i32)->unit)((xs as *i32),((@@builtin_i32_add as fn(i32, i32)->i32)((p as i32),(1 as i32)) as i32),(r as i32)) as unit);
       } else {
       
       }


### PR DESCRIPTION
Lowers expressions like 1+2 into `@@builtin_i32_add(1, 2)`