### PR TITLE
feat: eliminate group expressions before hir

### DIFF
--- a/compiler/eight-middle/src/hir/builder.rs
+++ b/compiler/eight-middle/src/hir/builder.rs
@@ -11,9 +11,9 @@
 use crate::hir::{
     HirAddressOfExpr, HirAssignExpr, HirBlockStmt, HirBooleanLiteralExpr, HirBreakStmt,
     HirCallExpr, HirConstantIndexExpr, HirConstructExpr, HirConstructExprArgument, HirContinueStmt,
-    HirDerefExpr, HirExpr, HirExprStmt, HirFunction, HirFunctionSignature, HirGroupExpr, HirIfStmt,
-    HirInstance, HirInstanceSignature, HirIntegerLiteralExpr, HirLetStmt, HirLoopStmt,
-    HirOffsetIndexExpr, HirReferenceExpr, HirReturnStmt, HirStmt, HirTrait, HirTraitSignature,
+    HirDerefExpr, HirExpr, HirExprStmt, HirFunction, HirFunctionSignature, HirIfStmt, HirInstance,
+    HirInstanceSignature, HirIntegerLiteralExpr, HirLetStmt, HirLoopStmt, HirOffsetIndexExpr,
+    HirReferenceExpr, HirReturnStmt, HirStmt, HirTrait, HirTraitSignature,
 };
 use crate::hir::{HirReferenceSymbol, HirTy};
 use crate::{HirResult, LinkageType};
@@ -221,19 +221,6 @@ impl<'hir> HirBuilder {
             field,
             field_span,
             expr: Box::new(expr),
-        }
-    }
-
-    /// Build a group expression
-    pub fn build_group_expr(
-        span: Span,
-        inner: HirExpr<'hir>,
-        ty: &'hir HirTy<'hir>,
-    ) -> HirGroupExpr<'hir> {
-        HirGroupExpr {
-            span,
-            inner: Box::new(inner),
-            ty,
         }
     }
 

--- a/compiler/eight-middle/src/hir/mod.rs
+++ b/compiler/eight-middle/src/hir/mod.rs
@@ -20,7 +20,6 @@ pub enum HirExpr<'hir> {
     OffsetIndex(HirOffsetIndexExpr<'hir>),
     Call(HirCallExpr<'hir>),
     Construct(HirConstructExpr<'hir>),
-    Group(HirGroupExpr<'hir>),
     AddressOf(HirAddressOfExpr<'hir>),
     Deref(HirDerefExpr<'hir>),
 }
@@ -35,7 +34,6 @@ impl<'hir> HirExpr<'hir> {
             HirExpr::OffsetIndex(e) => e.span,
             HirExpr::Call(e) => e.span,
             HirExpr::Construct(e) => e.span,
-            HirExpr::Group(e) => e.span,
             HirExpr::Reference(e) => e.span,
             HirExpr::AddressOf(e) => e.span,
             HirExpr::Deref(e) => e.span,
@@ -51,7 +49,6 @@ impl<'hir> HirExpr<'hir> {
             HirExpr::OffsetIndex(e) => e.ty,
             HirExpr::Call(e) => e.ty,
             HirExpr::Construct(e) => e.ty,
-            HirExpr::Group(e) => e.ty,
             HirExpr::Reference(e) => e.ty,
             HirExpr::AddressOf(e) => e.ty,
             HirExpr::Deref(e) => e.ty,
@@ -273,13 +270,6 @@ pub struct HirConstructExprArgument<'hir> {
     pub field: &'hir str,
     pub field_span: Span,
     pub expr: Box<HirExpr<'hir>>,
-}
-
-#[derive(Debug)]
-pub struct HirGroupExpr<'hir> {
-    pub span: Span,
-    pub inner: Box<HirExpr<'hir>>,
-    pub ty: &'hir HirTy<'hir>,
 }
 
 #[derive(Debug)]

--- a/compiler/eight-middle/src/passes/ast_lowering_pass/mod.rs
+++ b/compiler/eight-middle/src/passes/ast_lowering_pass/mod.rs
@@ -170,12 +170,12 @@ impl<'ast, 'hir> AstLoweringPass<'ast, 'hir> {
         ))
     }
 
+    /// Visit a group expression.
+    ///
+    /// These are eliminated completely, because the tree structure makes the order of evaluation
+    /// explicit.
     pub fn visit_group_expr(&mut self, node: &'ast AstGroupExpr) -> HirResult<HirExpr<'hir>> {
-        Ok(HirExpr::Group(HirBuilder::build_group_expr(
-            node.span,
-            self.visit_expr(node.inner)?,
-            self.cc.hir_uninitialized_type(),
-        )))
+        self.visit_expr(node.inner)
     }
 
     pub fn visit_integer_literal_expr(

--- a/compiler/eight-middle/src/passes/hir_lowering_pass/mod.rs
+++ b/compiler/eight-middle/src/passes/hir_lowering_pass/mod.rs
@@ -1,10 +1,10 @@
 use crate::builtin::CompilerIntrinsic;
 use crate::context::CompileContext;
+use crate::hir::HirTy;
 use crate::hir::{
     HirBooleanLiteralExpr, HirCallExpr, HirExpr, HirIntegerLiteralExpr, HirReferenceExpr,
 };
 use crate::hir::{HirExprStmt, HirFunction, HirLetStmt, HirStmt};
-use crate::hir::{HirGroupExpr, HirTy};
 use crate::hir::{HirModule, HirReferenceSymbol};
 use crate::mir::function::{MirFunction, MirFunctionBuilder};
 use crate::mir::module::MirModuleContext;
@@ -170,7 +170,6 @@ impl<'hir, 'mir> HirModuleLoweringPass<'mir> {
             HirExpr::Reference(e) => self.visit_reference_expr(b, cx, e),
             HirExpr::Call(e) => self.visit_call_expr(b, cx, e),
             HirExpr::BooleanLiteral(e) => self.visit_boolean_literal_expr(b, cx, e),
-            HirExpr::Group(e) => self.visit_group_expr(b, cx, e),
             HirExpr::AddressOf(_)
             | HirExpr::Deref(_)
             | HirExpr::ConstantIndex(_)
@@ -291,15 +290,6 @@ impl<'hir, 'mir> HirModuleLoweringPass<'mir> {
             _ => unimplemented!(),
         };
         Ok(value)
-    }
-
-    pub fn visit_group_expr(
-        &mut self,
-        b: &mut MirFunctionBuilder<'mir>,
-        cx: &MirModuleContext<'mir>,
-        expr: &'hir HirGroupExpr<'hir>,
-    ) -> MirResult<MirValueRef> {
-        self.visit_expr(b, cx, &expr.inner)
     }
 
     /// Translate a type into MIR.

--- a/compiler/eight-middle/src/passes/hir_simplify_pass/mod.rs
+++ b/compiler/eight-middle/src/passes/hir_simplify_pass/mod.rs
@@ -5,9 +5,9 @@ use crate::hir::builder::HirBuilder;
 use crate::hir::{
     HirAddressOfExpr, HirAssignExpr, HirBlockStmt, HirBooleanLiteralExpr, HirBreakStmt,
     HirCallExpr, HirConstantIndexExpr, HirConstructExpr, HirConstructExprArgument, HirContinueStmt,
-    HirDerefExpr, HirExpr, HirExprStmt, HirFunction, HirGroupExpr, HirIfStmt, HirInstance,
-    HirIntegerLiteralExpr, HirLetStmt, HirLoopStmt, HirModule, HirOffsetIndexExpr,
-    HirReferenceExpr, HirReferenceSymbol, HirReturnStmt, HirStmt,
+    HirDerefExpr, HirExpr, HirExprStmt, HirFunction, HirIfStmt, HirInstance, HirIntegerLiteralExpr,
+    HirLetStmt, HirLoopStmt, HirModule, HirOffsetIndexExpr, HirReferenceExpr, HirReferenceSymbol,
+    HirReturnStmt, HirStmt,
 };
 use eight_diagnostics::ice;
 
@@ -106,7 +106,6 @@ impl<'be> HirSimplifyPass<'be> {
             HirExpr::OffsetIndex(e) => self.visit_offset_index_expr(e),
             HirExpr::Call(e) => self.visit_call_expr(e),
             HirExpr::Construct(e) => self.visit_construct_expr(e),
-            HirExpr::Group(e) => self.visit_group_expr(e),
             HirExpr::AddressOf(e) => self.visit_address_of_expr(e),
             HirExpr::Deref(e) => self.visit_deref_expr(e),
         }
@@ -179,10 +178,6 @@ impl<'be> HirSimplifyPass<'be> {
 
     pub fn visit_construct_expr_argument(&mut self, expr: &mut HirConstructExprArgument<'be>) {
         self.visit_expr(&mut expr.expr);
-    }
-
-    pub fn visit_group_expr(&mut self, expr: &mut HirGroupExpr<'be>) {
-        self.visit_expr(&mut expr.inner);
     }
 
     pub fn visit_address_of_expr(&mut self, expr: &mut HirAddressOfExpr<'be>) {

--- a/compiler/eight-middle/src/passes/hir_textual_pass/mod.rs
+++ b/compiler/eight-middle/src/passes/hir_textual_pass/mod.rs
@@ -9,8 +9,8 @@
 
 use crate::hir::{
     HirAddressOfExpr, HirAssignExpr, HirBooleanLiteralExpr, HirCallExpr, HirConstantIndexExpr,
-    HirConstructExpr, HirConstructExprArgument, HirDerefExpr, HirExpr, HirFunction, HirGroupExpr,
-    HirInstance, HirIntegerLiteralExpr, HirOffsetIndexExpr, HirReferenceExpr, HirReferenceSymbol,
+    HirConstructExpr, HirConstructExprArgument, HirDerefExpr, HirExpr, HirFunction, HirInstance,
+    HirIntegerLiteralExpr, HirOffsetIndexExpr, HirReferenceExpr, HirReferenceSymbol,
 };
 use crate::hir::{
     HirBlockStmt, HirBreakStmt, HirContinueStmt, HirExprStmt, HirFunctionParameterSignature,
@@ -581,7 +581,6 @@ impl<'a> HirModuleTextualPass<'a> {
             HirExpr::OffsetIndex(e) => self.visit_offset_index_expr(e),
             HirExpr::Call(e) => self.visit_call_expr(e),
             HirExpr::Construct(e) => self.visit_construct_expr(e),
-            HirExpr::Group(e) => self.visit_group_expr(e),
             HirExpr::AddressOf(e) => self.visit_address_of_expr(e),
             HirExpr::Deref(e) => self.visit_deref_expr(e),
         };
@@ -726,16 +725,6 @@ impl<'a> HirModuleTextualPass<'a> {
             .append(self.arena.space())
             .append(self.visit_expr(&expr.expr))
             .append(self.arena.text(","))
-    }
-
-    pub fn visit_group_expr<'hir: 'a>(
-        &'a self,
-        expr: &'hir HirGroupExpr,
-    ) -> DocBuilder<'a, Arena<'a>> {
-        self.arena
-            .text("(")
-            .append(self.visit_expr(&expr.inner))
-            .append(self.arena.text(")"))
     }
 
     pub fn visit_address_of_expr<'hir: 'a>(

--- a/compiler/eight-middle/src/passes/hir_type_check_pass/mod.rs
+++ b/compiler/eight-middle/src/passes/hir_type_check_pass/mod.rs
@@ -2,9 +2,8 @@ mod typing_context;
 
 use crate::hir::{
     HirAddressOfExpr, HirAssignExpr, HirBooleanLiteralExpr, HirCallExpr, HirConstantIndexExpr,
-    HirConstructExpr, HirDerefExpr, HirExpr, HirFunction, HirGroupExpr, HirInstance,
-    HirIntegerLiteralExpr, HirOffsetIndexExpr, HirReferenceExpr, HirReferenceSymbol, HirStruct,
-    HirTrait,
+    HirConstructExpr, HirDerefExpr, HirExpr, HirFunction, HirInstance, HirIntegerLiteralExpr,
+    HirOffsetIndexExpr, HirReferenceExpr, HirReferenceSymbol, HirStruct, HirTrait,
 };
 use crate::hir::{
     HirBlockStmt, HirExprStmt, HirFunctionTy, HirIfStmt, HirLetStmt, HirLoopStmt, HirModule,
@@ -441,7 +440,6 @@ impl HirModuleTypeCheckerPass {
         match node {
             HirExpr::IntegerLiteral(e) => Self::enter_integer_literal_expr(cx, e),
             HirExpr::BooleanLiteral(e) => Self::enter_boolean_literal_expr(cx, e),
-            HirExpr::Group(e) => Self::enter_group_expr(cx, e),
             HirExpr::Reference(e) => Self::enter_reference_expr(cx, e),
             HirExpr::Assign(e) => Self::enter_assign_expr(cx, e),
             HirExpr::OffsetIndex(e) => Self::enter_offset_index_expr(cx, e),
@@ -461,7 +459,6 @@ impl HirModuleTypeCheckerPass {
         match node {
             HirExpr::IntegerLiteral(e) => Self::leave_integer_literal_expr(cx, e),
             HirExpr::BooleanLiteral(e) => Self::leave_boolean_literal_expr(cx, e),
-            HirExpr::Group(e) => Self::leave_group_expr(cx, e),
             HirExpr::Reference(e) => Self::leave_reference_expr(cx, e),
             HirExpr::Assign(e) => Self::leave_assign_expr(cx, e),
             HirExpr::OffsetIndex(e) => Self::leave_offset_index_expr(cx, e),
@@ -511,29 +508,6 @@ impl HirModuleTypeCheckerPass {
         cx: &mut TypingContext<'hir>,
         node: &mut HirBooleanLiteralExpr<'hir>,
     ) -> HirResult<()> {
-        node.ty = cx.substitute(node.ty)?;
-        Ok(())
-    }
-
-    /// Collect type constraints for a group expression.
-    ///
-    /// The grouping expression's type is inferred from the inner expression.
-    pub fn enter_group_expr<'hir>(
-        cx: &mut TypingContext<'hir>,
-        node: &mut HirGroupExpr<'hir>,
-    ) -> HirResult<()> {
-        node.ty = Self::visit_type(cx, node.ty)?;
-        Self::enter_expr(cx, &mut node.inner)?;
-        cx.infer_group_expr(node, node.ty)?;
-        Ok(())
-    }
-
-    /// Perform substitution for a group expression.
-    pub fn leave_group_expr<'hir>(
-        cx: &mut TypingContext<'hir>,
-        node: &mut HirGroupExpr<'hir>,
-    ) -> HirResult<()> {
-        Self::leave_expr(cx, &mut node.inner)?;
         node.ty = cx.substitute(node.ty)?;
         Ok(())
     }

--- a/compiler/eight-middle/src/passes/hir_type_check_pass/typing_context.rs
+++ b/compiler/eight-middle/src/passes/hir_type_check_pass/typing_context.rs
@@ -1,8 +1,8 @@
 use crate::context::CompileContext;
 use crate::hir::{
     HirAddressOfExpr, HirAssignExpr, HirBooleanLiteralExpr, HirCallExpr, HirConstantIndexExpr,
-    HirConstructExpr, HirDerefExpr, HirExpr, HirFunctionTy, HirGroupExpr, HirIntegerLiteralExpr,
-    HirMetaTy, HirModuleSignature, HirOffsetIndexExpr, HirReferenceExpr, HirReferenceSymbol, HirTy,
+    HirConstructExpr, HirDerefExpr, HirExpr, HirFunctionTy, HirIntegerLiteralExpr, HirMetaTy,
+    HirModuleSignature, HirOffsetIndexExpr, HirReferenceExpr, HirReferenceSymbol, HirTy,
 };
 use crate::passes::hir_type_check_pass::{
     Constraint, DereferenceableConstraint, EqualityConstraint, FieldProjectionConstraint,
@@ -657,17 +657,6 @@ impl<'hir> TypingContext<'hir> {
         Ok(())
     }
 
-    /// Infer the type of a group expression.
-    pub fn infer_group_expr(
-        &mut self,
-        expr: &mut HirGroupExpr<'hir>,
-        expectation: &'hir HirTy<'hir>,
-    ) -> HirResult<()> {
-        self.infer(&mut expr.inner, expectation)?;
-        self.constrain_eq(expectation, expr.ty, expr.span, expr.inner.span());
-        Ok(())
-    }
-
     /// Infer the expression's type based on its expected type.
     ///
     /// This collects the necessary constraints on the expression's type based on its structure. The
@@ -689,7 +678,6 @@ impl<'hir> TypingContext<'hir> {
             HirExpr::Construct(e) => self.infer_construct_expr(e, expectation),
             HirExpr::AddressOf(e) => self.infer_address_of_expr(e, expectation),
             HirExpr::Deref(e) => self.infer_deref_expr(e, expectation),
-            HirExpr::Group(e) => self.infer_group_expr(e, expectation),
         }
     }
 


### PR DESCRIPTION
They don't provide any value once turned into a tree, so we might as well
discard them before lowering to HIR.