### PR TITLE
feat: parse `ptr` as void pointer type

### DIFF
--- a/compiler/eight-middle/src/passes/ast_lowering_pass/mod.rs
+++ b/compiler/eight-middle/src/passes/ast_lowering_pass/mod.rs
@@ -830,6 +830,7 @@ impl<'ast, 'hir> AstLoweringPass<'ast, 'hir> {
                         .hir_nominal_type(self.session.intern_str(&t.name.name), t.name.span),
                 }
             }
+            AstType::Ptr(_) => self.session.hir_pointer_type(self.session.hir_unit_type()),
             AstType::Pointer(t) => self.session.hir_pointer_type(self.visit_type(t.inner)?),
         };
         Ok(ty)

--- a/compiler/eight-syntax/src/ast.rs
+++ b/compiler/eight-syntax/src/ast.rs
@@ -351,6 +351,7 @@ pub struct AstIdentifier {
 pub enum AstType<'ast> {
     Unit(AstUnitType),
     Integer32(AstInteger32Type),
+    Ptr(AstPtrType),
     Pointer(AstPointerType<'ast>),
     Named(AstNamedType<'ast>),
     Boolean(AstBooleanType),
@@ -363,6 +364,7 @@ impl AstType<'_> {
             AstType::Unit(t) => t.span,
             AstType::Integer32(t) => t.span,
             AstType::Pointer(t) => t.span,
+            AstType::Ptr(t) => t.span,
             AstType::Named(t) => t.span,
             AstType::Boolean(t) => t.span,
         }
@@ -384,6 +386,12 @@ pub struct AstInteger32Type {
 #[cfg_attr(feature = "serde", derive(serde::Serialize))]
 #[derive(Debug)]
 pub struct AstBooleanType {
+    pub span: Span,
+}
+
+#[cfg_attr(feature = "serde", derive(serde::Serialize))]
+#[derive(Debug)]
+pub struct AstPtrType {
     pub span: Span,
 }
 

--- a/compiler/eight-syntax/src/parser.rs
+++ b/compiler/eight-syntax/src/parser.rs
@@ -5,9 +5,9 @@ use crate::ast::{
     AstContinueStmt, AstDotIndexExpr, AstExpr, AstExprStmt, AstForStmt, AstForStmtInitializer,
     AstFunctionItem, AstFunctionParameterItem, AstGroupExpr, AstIdentifier, AstIfStmt,
     AstInstanceItem, AstInteger32Type, AstIntegerLiteralExpr, AstItem, AstLetStmt, AstNamedType,
-    AstPointerType, AstReferenceExpr, AstReturnStmt, AstStmt, AstStructItem, AstStructMemberItem,
-    AstTraitFunctionItem, AstTraitItem, AstTranslationUnit, AstType, AstTypeItem,
-    AstTypeParameterItem, AstUnaryOp, AstUnaryOpExpr, AstUnitType,
+    AstPointerType, AstPtrType, AstReferenceExpr, AstReturnStmt, AstStmt, AstStructItem,
+    AstStructMemberItem, AstTraitFunctionItem, AstTraitItem, AstTranslationUnit, AstType,
+    AstTypeItem, AstTypeParameterItem, AstUnaryOp, AstUnaryOpExpr, AstUnitType,
 };
 use crate::lexer::Lexer;
 use crate::tok::{Token, TokenType};
@@ -1318,6 +1318,11 @@ impl<'ast> Parser<'_, 'ast> {
                     let node = AstUnitType { span: id.span };
                     Ok(AstType::Unit(node))
                 }
+                "ptr" => {
+                    let id = self.parse_identifier()?;
+                    let node = AstPtrType { span: id.span };
+                    Ok(AstType::Ptr(node))
+                }
                 _ => Ok(AstType::Named(self.parse_named_type()?)),
             },
             TokenType::Star => Ok(AstType::Pointer(self.parse_pointer_type()?)),
@@ -1407,6 +1412,12 @@ mod tests {
             let production = p.parse_type();
             let production = assert_ok!(production);
             assert!(matches!(&production, AstType::Boolean(_)));
+        });
+
+        assert_parse!("ptr", |p: &mut Parser| {
+            let production = p.parse_type();
+            let production = assert_ok!(production);
+            assert!(matches!(&production, AstType::Ptr(_)));
         });
     }
 

--- a/compiler/eight-tests/tests/snapshots/stdlib__evaluate_stdlib.snap
+++ b/compiler/eight-tests/tests/snapshots/stdlib__evaluate_stdlib.snap
@@ -5,7 +5,7 @@ info:
   args:
     - "-"
     - "--emit-hir"
-  stdin: "intrinsic_type bool;\n\ninstance And<bool, bool> {\n  intrinsic_fn and(a: bool, b: bool) -> bool;\n}\ninstance Or<bool, bool> {\n  intrinsic_fn or(a: bool, b: bool) -> bool;\n}\n\ninstance Eq<bool, bool> {\n  intrinsic_fn eq(a: bool, b: bool) -> bool;\n  intrinsic_fn neq(a: bool, b: bool) -> bool;\n}\n\ninstance Not<bool, bool> {\n  intrinsic_fn not(a: bool) -> bool;\n}\n\nintrinsic_type i32;\n\ninstance Add<i32, i32, i32> {\n  intrinsic_fn add(a: i32, b: i32) -> i32;\n}\n\ninstance Sub<i32, i32, i32> {\n  intrinsic_fn sub(a: i32, b: i32) -> i32;\n}\n\ninstance Mul<i32, i32, i32> {\n  intrinsic_fn mul(a: i32, b: i32) -> i32;\n}\n\ninstance Div<i32, i32, i32> {\n  intrinsic_fn div(a: i32, b: i32) -> i32;\n}\n\ninstance Rem<i32, i32, i32> {\n  intrinsic_fn rem(a: i32, b: i32) -> i32;\n}\n\ninstance Eq<i32, i32> {\n  intrinsic_fn eq(a: i32, b: i32) -> bool;\n  intrinsic_fn neq(a: i32, b: i32) -> bool;\n}\n\ninstance Ord<i32, i32> {\n  intrinsic_fn lt(a: i32, b: i32) -> bool;\n  intrinsic_fn gt(a: i32, b: i32) -> bool;\n  intrinsic_fn le(a: i32, b: i32) -> bool;\n  intrinsic_fn ge(a: i32, b: i32) -> bool;\n}\n\ninstance Neg<i32, i32> {\n  intrinsic_fn neg(a: i32) -> i32;\n}\n\nintrinsic_fn malloc<T>(size: i32) -> *T;\nintrinsic_fn free<T>(ptr: *T) -> unit;\nintrinsic_fn exit() -> unit;\n\ntrait Add<A, B, R> {\n  fn add(a: A, b: B) -> R;\n}\n\ntrait Sub<A, B, R> {\n  fn sub(a: A, b: B) -> R;\n}\n\ntrait Mul<A, B, R> {\n  fn mul(a: A, b: B) -> R;\n}\n\ntrait Div<A, B, R> {\n  fn div(a: A, b: B) -> R;\n}\n\ntrait Rem<A, B, R> {\n  fn rem(a: A, b: B) -> R;\n}\n\ntrait Eq<A, B> {\n  fn eq(a: A, b: B) -> bool;\n  fn neq(a: A, b: B) -> bool;\n}\n\ntrait Ord<A, B> {\n  fn lt(a: A, b: B) -> bool;\n  fn gt(a: A, b: B) -> bool;\n  fn le(a: A, b: B) -> bool;\n  fn ge(a: A, b: B) -> bool;\n}\n\ntrait Neg<A, R> {\n  fn neg(a: A) -> R;\n}\n\ntrait Not<A, R> {\n  fn not(a: A) -> R;\n}\n\ntrait And<A, B> {\n  fn and(a: A, b: B) -> bool;\n}\n\ntrait Or<A, B> {\n  fn or(a: A, b: B) -> bool;\n}\n\nintrinsic_type unit;\n\n"
+  stdin: "intrinsic_type bool;\n\ninstance And<bool, bool> {\n  intrinsic_fn and(a: bool, b: bool) -> bool;\n}\ninstance Or<bool, bool> {\n  intrinsic_fn or(a: bool, b: bool) -> bool;\n}\n\ninstance Eq<bool, bool> {\n  intrinsic_fn eq(a: bool, b: bool) -> bool;\n  intrinsic_fn neq(a: bool, b: bool) -> bool;\n}\n\ninstance Not<bool, bool> {\n  intrinsic_fn not(a: bool) -> bool;\n}\n\nintrinsic_type i32;\n\ninstance Add<i32, i32, i32> {\n  intrinsic_fn add(a: i32, b: i32) -> i32;\n}\n\ninstance Sub<i32, i32, i32> {\n  intrinsic_fn sub(a: i32, b: i32) -> i32;\n}\n\ninstance Mul<i32, i32, i32> {\n  intrinsic_fn mul(a: i32, b: i32) -> i32;\n}\n\ninstance Div<i32, i32, i32> {\n  intrinsic_fn div(a: i32, b: i32) -> i32;\n}\n\ninstance Rem<i32, i32, i32> {\n  intrinsic_fn rem(a: i32, b: i32) -> i32;\n}\n\ninstance Eq<i32, i32> {\n  intrinsic_fn eq(a: i32, b: i32) -> bool;\n  intrinsic_fn neq(a: i32, b: i32) -> bool;\n}\n\ninstance Ord<i32, i32> {\n  intrinsic_fn lt(a: i32, b: i32) -> bool;\n  intrinsic_fn gt(a: i32, b: i32) -> bool;\n  intrinsic_fn le(a: i32, b: i32) -> bool;\n  intrinsic_fn ge(a: i32, b: i32) -> bool;\n}\n\ninstance Neg<i32, i32> {\n  intrinsic_fn neg(a: i32) -> i32;\n}\n\nintrinsic_fn __libc_malloc(size: i32) -> ptr;\nintrinsic_fn __libc_free(ptr: ptr) -> unit;\nintrinsic_fn __libc__exit(status: i32) -> unit;\n\ntrait Add<A, B, R> {\n  fn add(a: A, b: B) -> R;\n}\n\ntrait Sub<A, B, R> {\n  fn sub(a: A, b: B) -> R;\n}\n\ntrait Mul<A, B, R> {\n  fn mul(a: A, b: B) -> R;\n}\n\ntrait Div<A, B, R> {\n  fn div(a: A, b: B) -> R;\n}\n\ntrait Rem<A, B, R> {\n  fn rem(a: A, b: B) -> R;\n}\n\ntrait Eq<A, B> {\n  fn eq(a: A, b: B) -> bool;\n  fn neq(a: A, b: B) -> bool;\n}\n\ntrait Ord<A, B> {\n  fn lt(a: A, b: B) -> bool;\n  fn gt(a: A, b: B) -> bool;\n  fn le(a: A, b: B) -> bool;\n  fn ge(a: A, b: B) -> bool;\n}\n\ntrait Neg<A, R> {\n  fn neg(a: A) -> R;\n}\n\ntrait Not<A, R> {\n  fn not(a: A) -> R;\n}\n\ntrait And<A, B> {\n  fn and(a: A, b: B) -> bool;\n}\n\ntrait Or<A, B> {\n  fn or(a: A, b: B) -> bool;\n}\n\nintrinsic_type unit;\n\n"
 ---
 success: false
 exit_code: 1
@@ -23,9 +23,9 @@ hir_module {
     
     
     // module functions
-    fn exit() -> unit;
-    fn free<$1'0>(ptr: *$1'0) -> unit;
-    fn malloc<$1'0>(size: i32) -> *$1'0;
+    fn __libc__exit(status: i32) -> unit;
+    fn __libc_free(ptr: *unit) -> unit;
+    fn __libc_malloc(size: i32) -> *unit;
     
     // module traits
     trait Add<$1'0, $1'1, $1'2> {
@@ -161,8 +161,8 @@ hir_module {
 ; ModuleID = 'eightc'
 source_filename = "eightc"
 
-declare void @exit()
+declare void @__libc__exit(i32 %0)
 
-declare void @free(ptr %0)
+declare void @__libc_free(ptr %0)
 
-declare ptr @malloc(i32 %0)
+declare ptr @__libc_malloc(i32 %0)

--- a/stdlib/libc.eight
+++ b/stdlib/libc.eight
@@ -1,3 +1,3 @@
-intrinsic_fn malloc<T>(size: i32) -> *T;
-intrinsic_fn free<T>(ptr: *T) -> unit;
-intrinsic_fn exit() -> unit;
+intrinsic_fn __libc_malloc(size: i32) -> ptr;
+intrinsic_fn __libc_free(ptr: ptr) -> unit;
+intrinsic_fn __libc__exit(status: i32) -> unit;


### PR DESCRIPTION
The frontend doesn't handle or type-check this at the moment, but it's
intended to be an opaque pointer to some unknown type that the user has
to bitcast in order to use.